### PR TITLE
Add specialized parsers for Prebid repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,22 @@ CLI tool that allows users to:
 - Parse through specified directories in the repo
 - Extract data using configurable parsers
 - Supports interactive menus for preconfigured repos
-- Extensible parsing system (default, markdown, OpenAPI)
+- Extensible parsing system with specialized parsers for Prebid repositories
+- Multi-path parsing for complex repository structures
+- Automatic filename generation with consistent naming conventions
+
+**Supported Repositories:**
+- **Prebid.js** - JavaScript ad serving framework modules and adapters
+- **Prebid Server Go** - Go implementation with bid adapters, analytics, and modules
+- **Prebid Server Java** - Java implementation with bidders, privacy, and general modules  
+- **Prebid Documentation** - Documentation site with adapter and module documentation
+
+**Features:**
+- Underscore to space conversion for better readability
+- Category-based organization (Bid Adapters, Analytics Adapters, etc.)
+- Master version override for documentation repository
+- Special suffix handling (RtdProvider, AnalyticsAdapter, VideoProvider)
+- JSON output for programmatic access
 
 **Usage:**
 ```bash
@@ -37,6 +52,12 @@ repo-modules-by-version --repo owner/repo --version v1.0.0
 
 # List available repos
 repo-modules-by-version --list-repos
+
+# Examples with preconfigured repos
+repo-modules-by-version --repo prebid-js --version v9.51.0
+repo-modules-by-version --repo prebid-server --version v3.8.0
+repo-modules-by-version --repo prebid-server-java --version v3.27.0
+repo-modules-by-version --repo prebid-docs  # Always uses master
 ```
 
 ## Dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,22 @@ CLI tool that allows users to:
 - Parse through specified directories in the repo
 - Extract data using configurable parsers
 - Supports interactive menus for preconfigured repos
-- Extensible parsing system (default, markdown, OpenAPI)
+- Extensible parsing system with specialized parsers for Prebid repositories
+- Multi-path parsing for complex repository structures
+- Automatic filename generation with consistent naming conventions
+
+**Supported Repositories:**
+- **Prebid.js** - JavaScript ad serving framework modules and adapters
+- **Prebid Server Go** - Go implementation with bid adapters, analytics, and modules
+- **Prebid Server Java** - Java implementation with bidders, privacy, and general modules  
+- **Prebid Documentation** - Documentation site with adapter and module documentation
+
+**Features:**
+- Underscore to space conversion for better readability
+- Category-based organization (Bid Adapters, Analytics Adapters, etc.)
+- Master version override for documentation repository
+- Special suffix handling (RtdProvider, AnalyticsAdapter, VideoProvider)
+- JSON output for programmatic access
 
 **Usage:**
 ```bash
@@ -37,6 +52,12 @@ repo-modules-by-version --repo owner/repo --version v1.0.0
 
 # List available repos
 repo-modules-by-version --list-repos
+
+# Examples with preconfigured repos
+repo-modules-by-version --repo prebid-js --version v9.51.0
+repo-modules-by-version --repo prebid-server --version v3.8.0
+repo-modules-by-version --repo prebid-server-java --version v3.27.0
+repo-modules-by-version --repo prebid-docs  # Always uses master
 ```
 
 ## Dependencies

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -25,7 +25,22 @@ CLI tool that allows users to:
 - Parse through specified directories in the repo
 - Extract data using configurable parsers
 - Supports interactive menus for preconfigured repos
-- Extensible parsing system (default, markdown, OpenAPI)
+- Extensible parsing system with specialized parsers for Prebid repositories
+- Multi-path parsing for complex repository structures
+- Automatic filename generation with consistent naming conventions
+
+**Supported Repositories:**
+- **Prebid.js** - JavaScript ad serving framework modules and adapters
+- **Prebid Server Go** - Go implementation with bid adapters, analytics, and modules
+- **Prebid Server Java** - Java implementation with bidders, privacy, and general modules  
+- **Prebid Documentation** - Documentation site with adapter and module documentation
+
+**Features:**
+- Underscore to space conversion for better readability
+- Category-based organization (Bid Adapters, Analytics Adapters, etc.)
+- Master version override for documentation repository
+- Special suffix handling (RtdProvider, AnalyticsAdapter, VideoProvider)
+- JSON output for programmatic access
 
 **Usage:**
 ```bash
@@ -37,6 +52,12 @@ repo-modules-by-version --repo owner/repo --version v1.0.0
 
 # List available repos
 repo-modules-by-version --list-repos
+
+# Examples with preconfigured repos
+repo-modules-by-version --repo prebid-js --version v9.51.0
+repo-modules-by-version --repo prebid-server --version v3.8.0
+repo-modules-by-version --repo prebid-server-java --version v3.27.0
+repo-modules-by-version --repo prebid-docs  # Always uses master
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ src/
 
 - `GITHUB_TOKEN` - GitHub Personal Access Token for API access (optional but recommended for higher rate limits)
 
-Last updated: 2025-06-26 15:07:01
+Last updated: 2025-06-26 15:23:35

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ cp .env.example .env
 
 ### repo-modules-by-version
 
+Extract and categorize modules/adapters from GitHub repositories with specialized parsing for Prebid projects.
+
+**Supported Repositories:**
+- **prebid-js** - Prebid.js modules and adapters
+- **prebid-server** - Prebid Server Go implementation  
+- **prebid-server-java** - Prebid Server Java implementation
+- **prebid-docs** - Prebid documentation site
+
+**Features:**
+- Category-based organization (Bid Adapters, Analytics Adapters, etc.)
+- Underscore to space conversion for readability
+- Multi-path parsing for complex repositories
+- Automatic filename generation
+- JSON output for programmatic access
+
 ```bash
 # Interactive mode
 repo-modules-by-version
@@ -26,6 +41,12 @@ repo-modules-by-version --repo owner/repo --version v1.0.0
 
 # List available repos
 repo-modules-by-version --list-repos
+
+# Examples with preconfigured repos
+repo-modules-by-version --repo prebid-js --version v9.51.0
+repo-modules-by-version --repo prebid-server --version v3.8.0
+repo-modules-by-version --repo prebid-server-java --version v3.27.0
+repo-modules-by-version --repo prebid-docs  # Always uses master
 ```
 
 ## Development
@@ -103,4 +124,4 @@ src/
 
 - `GITHUB_TOKEN` - GitHub Personal Access Token for API access (optional but recommended for higher rate limits)
 
-Last updated: 2025-06-25 17:47:52
+Last updated: 2025-06-26 15:07:01

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ src/
 
 - `GITHUB_TOKEN` - GitHub Personal Access Token for API access (optional but recommended for higher rate limits)
 
-Last updated: 2025-06-26 15:23:35
+Last updated: 2025-06-26 16:01:38

--- a/prebid.github.io_modules_version_master.txt
+++ b/prebid.github.io_modules_version_master.txt
@@ -1,0 +1,1872 @@
+Repository: prebid/prebid.github.io
+Version: master
+
+Prebid Documentation Categories:
+========================================
+
+📦 Bid Adapters (670):
+------------------------------
+  • 152media
+  • 1accord
+  • 33across
+  • 9MediaOnline
+  • 9dotsmedia
+  • a1media
+  • a4g
+  • aax
+  • ablida
+  • aceex
+  • acuityads
+  • ad2iction
+  • adWMG
+  • adagio
+  • adasta
+  • adbite
+  • adblender
+  • adbookpsp
+  • adbutler
+  • addefend
+  • addigi
+  • adelement
+  • adf
+  • adfusion
+  • adgeneration
+  • adgrid
+  • adhash
+  • adhese
+  • adinify
+  • adipolo
+  • adkernel
+  • adkernelAdn
+  • adliveconnect
+  • adliveplus
+  • adlivetech
+  • adman
+  • admaru
+  • admatic
+  • admaticde
+  • admedia
+  • admixer
+  • admixeradx
+  • adnow
+  • adnuntius
+  • adocean
+  • adomega
+  • adoppler
+  • adot
+  • adpartner
+  • adplus
+  • adpluto
+  • adpluto_dsp
+  • adpone
+  • adport
+  • adprime
+  • adquery
+  • adrelevantis
+  • adrino
+  • adriver
+  • ads_interactive
+  • adsinteractive
+  • adsolut
+  • adsparc
+  • adspirit
+  • adstir
+  • adsyield
+  • adt
+  • adtarget
+  • adtarget_org
+  • adtelligent
+  • adtonos
+  • adtrgtme
+  • adtrue
+  • aduptech
+  • advangelists
+  • adverxo
+  • adview
+  • adxcg
+  • adyoulike
+  • adzymic
+  • afp
+  • aidem
+  • aja
+  • akcelo
+  • algorix
+  • alkimi
+  • ampliffy
+  • amx
+  • amx-server
+  • andBeyondMedia
+  • aniview
+  • anyclip
+  • aol
+  • apacdex
+  • apester
+  • appier
+  • appierBR
+  • appierExt
+  • appierGM
+  • applogy
+  • appnexus
+  • appstock
+  • appush
+  • apstream
+  • artechnology
+  • arteebee
+  • aseal
+  • aso
+  • astraone
+  • attekmi
+  • audienceNetwork
+  • audiencemedia
+  • audiencerun
+  • automatad
+  • avantisvideo
+  • avct
+  • axis
+  • axonix
+  • bcm
+  • bcmint
+  • beachfront
+  • bedigitech
+  • beintoo
+  • beop
+  • between
+  • bidbuddy
+  • biddo
+  • bidgency
+  • bidglass
+  • bidmachine
+  • bidmyadz
+  • bidscube
+  • bidsmind
+  • bidstack
+  • bidsxchange
+  • bidtheatre
+  • big-richmedia
+  • bigoad
+  • bitmedia
+  • blasto
+  • bliink
+  • blockthrough
+  • blue
+  • bluebillywig
+  • bluesea
+  • bms
+  • bmtm
+  • boldwin
+  • brainx
+  • brainy
+  • brave
+  • brid
+  • bridgeupp
+  • bridgewell
+  • brightroll
+  • browsi
+  • bucksense
+  • buzzoola
+  • bwx
+  • c1x
+  • cadent_aperture_mx
+  • caroda
+  • ccx
+  • chtnw
+  • cleanmedianet
+  • clickforce
+  • codefuel
+  • cointraffic
+  • coinzilla
+  • collectcent
+  • colombia
+  • colossus
+  • colossusssp
+  • compass
+  • conceptx
+  • concert
+  • condorx
+  • connatix
+  • connectad
+  • connektai
+  • consumable
+  • consumable-server
+  • contentexchange
+  • contentignite
+  • contxtful
+  • converge
+  • copper6
+  • copper6ssp
+  • cordless
+  • cox
+  • cpmstar
+  • craft
+  • criteo
+  • cwire
+  • dailymotion
+  • danmarket
+  • datablocks
+  • datawrkz
+  • deepintent
+  • definemedia
+  • defymedia
+  • deltaprojects
+  • denakop
+  • dexerto
+  • dianomi
+  • didnadisplay
+  • didnavideo
+  • digiad
+  • digitalmatter
+  • discovery
+  • displayio
+  • displayioads
+  • districtm
+  • districtmdmx
+  • distroscale
+  • divreach
+  • djax
+  • dmx
+  • doceree
+  • docereeadmanager
+  • dochase
+  • driftpixel
+  • dsp_geniee
+  • dspx
+  • duration
+  • dxkulture
+  • e_volution
+  • easybid
+  • ebdr
+  • eclickads
+  • edge226
+  • ehealthcaresolutions
+  • eightPod
+  • embimedia
+  • emetriq
+  • emtv
+  • engageadx
+  • engagebdr
+  • engageya
+  • eplanning
+  • epom
+  • epomDspBidAdapter
+  • epsilon
+  • equativ
+  • ergadx
+  • escalax
+  • eskimi
+  • etarget
+  • evtech
+  • exads
+  • exco
+  • eywamedia
+  • fairtrade
+  • featureforward
+  • feedad
+  • felixads
+  • filmzie
+  • finative
+  • flipp
+  • fluct
+  • freedomadnetwork
+  • freepass
+  • freewheelssp
+  • frvradn
+  • futureads
+  • fwssp
+  • fyber
+  • gambid
+  • gamma
+  • gamoshi
+  • getintent
+  • giants
+  • gjirafa
+  • glimpse
+  • global_sun
+  • globalsun
+  • glomex
+  • glomexbidder
+  • gmossp
+  • gnet
+  • go2net
+  • goldbach
+  • gothamads
+  • gourmetads
+  • greedygame
+  • greenbids
+  • grid
+  • gridNM
+  • growads
+  • gumgum
+  • gxone
+  • h12media
+  • headbidder
+  • headbidding
+  • holid
+  • houseofpubs
+  • huaweiads
+  • huddledmasses
+  • hybrid
+  • hypelab
+  • hyperbrainz
+  • ias
+  • idx
+  • iionads
+  • illumin
+  • imds
+  • impactify
+  • improvedigital
+  • incrementx
+  • indiecue
+  • infytv
+  • inmar
+  • inmobi
+  • innity
+  • inskin
+  • insticator
+  • integr8
+  • interactiveOffers
+  • intertech
+  • invamia
+  • invibes
+  • iprom
+  • iqm
+  • iqx
+  • iqzone
+  • ivs
+  • ix
+  • ix-server
+  • jamojar
+  • janet
+  • jdpmedia
+  • jixie
+  • justpremium
+  • jwplayer
+  • kargo
+  • kidoz
+  • kimberlite
+  • kiviads
+  • kobler
+  • krushmedia
+  • kuantyx
+  • kubient
+  • kueez
+  • kueezrtb
+  • kumma
+  • lane4
+  • lasso
+  • lemmadigital
+  • lifestreet
+  • limelightDigital
+  • livewrapped
+  • lkqd
+  • lm_kiviads
+  • lockerdome
+  • logan
+  • logicad
+  • loopme
+  • loyal
+  • lucead
+  • lunamedia
+  • lunamediahb
+  • luponmedia
+  • mabidder
+  • madsense
+  • madvertise
+  • malltv
+  • mantis
+  • markapp
+  • marsmedia
+  • mathildeads
+  • matomy
+  • mediaConsortium
+  • mediabrama
+  • mediaeyes
+  • mediaforce
+  • mediafuse
+  • mediago
+  • mediaimpact
+  • mediakeys
+  • medianet
+  • mediasniper
+  • mediasquare
+  • melozen
+  • metax
+  • mgid
+  • mgidX
+  • michao
+  • microad
+  • minutemedia
+  • minutemediaplus
+  • missena
+  • mobfoxpb
+  • mobilefuse
+  • mobkoi
+  • mobupps
+  • monetix
+  • monetixads
+  • motionspots
+  • motorik
+  • movingup
+  • my6sense
+  • mytarget
+  • nativery
+  • nativo
+  • netaddiction
+  • newspassid
+  • nextMillennium
+  • nextroll
+  • nexverse
+  • nexx360
+  • ninthdecimal
+  • nobid
+  • ocm
+  • oftmedia
+  • ogury
+  • omnidex
+  • oms
+  • onedisplay
+  • onemobile
+  • oneplanetonly
+  • onetag
+  • onomagic
+  • opamarketplace
+  • open8
+  • openweb
+  • openwebvideo
+  • openwebxchange
+  • openx
+  • openxoutstream
+  • operaads
+  • oppamedia
+  • opsco
+  • optable
+  • optidigital
+  • optimatic
+  • optimera
+  • optout
+  • oraki
+  • orangeclickmedia
+  • orbidder
+  • orbitsoft
+  • otm
+  • ottadvisors
+  • outbrain
+  • outbrain_old
+  • ownadx
+  • ozone
+  • padsquad
+  • pagescience
+  • pangle
+  • peak226
+  • performax
+  • pgam
+  • pgammedia
+  • pgamssp
+  • pilotx
+  • pixad
+  • pixelpluses
+  • pixfuture
+  • playdigo
+  • playwire
+  • pollux
+  • polymorph
+  • preciso
+  • prisma
+  • prismassp
+  • programmaticX
+  • programmatica
+  • projectagora
+  • proxistore
+  • pstudio
+  • pubcircle
+  • pubgenius
+  • publir
+  • pubmatic
+  • pubnative
+  • pubrise
+  • pubtech
+  • pubx
+  • pulsepoint
+  • pwbid
+  • pxyz
+  • qortex
+  • qt
+  • quantcast
+  • quantum
+  • quantumdex
+  • qwarry
+  • r2b2
+  • rads
+  • rakuten
+  • ras
+  • readpeak
+  • rediads
+  • redtram
+  • relaido
+  • relay
+  • relevantdigital
+  • relevatehealth
+  • resetdigital
+  • responsiveads
+  • retailspot
+  • revbid
+  • revcontent
+  • rexrtb
+  • rhythmone
+  • richaudience
+  • ringieraxelspringer
+  • rise
+  • risexchange
+  • rixengine
+  • robusta
+  • rocketlab
+  • rockyou
+  • roundel
+  • rtbanalytica
+  • rtbdemand_com
+  • rtbhouse
+  • rtbsape
+  • rtbstack
+  • rubicon
+  • rxnetwork
+  • rxrtb
+  • sa_lunamedia
+  • saambaa
+  • sara
+  • scattered
+  • screencore
+  • seedingAlliance
+  • seedtag
+  • selectmedia
+  • selectmediavideo
+  • setupad
+  • sharethrough
+  • shinez
+  • shinezRtb
+  • showheroes-bs
+  • silvermob
+  • silverpush
+  • slimcut
+  • smaato
+  • smartadline
+  • smartadserver
+  • smarthub
+  • smartico
+  • smartx
+  • smartyads
+  • smartytech
+  • smilewanted
+  • smn
+  • smoot
+  • smrtconnect
+  • snigel
+  • somoaudience
+  • sonic_twist
+  • sonobi
+  • sovrn
+  • sparteo
+  • spinx
+  • spotx
+  • ssmas
+  • sspBC
+  • ssp_geniee
+  • stackadapt
+  • stailamedia
+  • startio
+  • stellormedia
+  • stickyadstv
+  • stn
+  • streamkey
+  • streamlyn
+  • streamvision
+  • stroeerCore
+  • stv
+  • sublime
+  • suntContent
+  • supply2
+  • synacormedia
+  • taboola
+  • tagoras
+  • talkads
+  • tapnative
+  • tappx
+  • targetvideo
+  • teads
+  • teal
+  • telaria
+  • temedya
+  • tgm
+  • theAdx
+  • themoneytizer
+  • tpmn
+  • tradplus
+  • trafficgate
+  • trafficroots
+  • tredio
+  • tremor
+  • trion
+  • triplelift
+  • triplelift_native
+  • truereach
+  • trustedstack
+  • trustx
+  • trustxstandalone
+  • ttd
+  • turktelekom
+  • twistDigital
+  • ucfunnel
+  • underdogmedia
+  • undertone
+  • unibots
+  • unicorn
+  • uniquest
+  • unruly
+  • uol
+  • urekamedia
+  • valuad
+  • valueimpression
+  • vdoai
+  • velonium
+  • ventes
+  • vertamedia
+  • viant
+  • vibrantmedia
+  • vidazoo
+  • vidcrunch
+  • vidcrunchllc
+  • videobyte
+  • videoheroes
+  • videonow
+  • videoreach
+  • vidoomy
+  • viewdeos
+  • viewdeosDX
+  • vimayx
+  • viously
+  • viqeo
+  • visiblemeasures
+  • vistars
+  • visx
+  • vlyby
+  • voisetech
+  • vox
+  • vrtcal
+  • vungle
+  • vuukle
+  • waardex
+  • waardex_ak
+  • welect
+  • widespace
+  • winr
+  • wipes
+  • xe
+  • xendiz
+  • xtrmqb
+  • yahooAdvertising
+  • yandex
+  • yeahmobi
+  • yieldbot
+  • yieldlab
+  • yieldlift
+  • yieldlove
+  • yieldmo
+  • yieldnexus
+  • yieldone
+  • yobee
+  • zeroclickfraud
+  • zeta_global
+  • zeta_global_ssp
+  • zmaticoo
+
+📦 Analytics Adapters (68):
+------------------------------
+  • 33across
+  • AsteriobidPbm
+  • adWMG
+  • adagio
+  • adkernelAdn
+  • adloox
+  • adnuntius
+  • advRed
+  • adxcg
+  • adxpremium
+  • agma
+  • appier
+  • assertiveYield
+  • asteriobid
+  • ats
+  • audigent
+  • automatad
+  • bidwatch
+  • browsi
+  • bydata
+  • concert
+  • datablocks
+  • eightPod
+  • eplanning
+  • finteza
+  • generic
+  • greenbids
+  • growthcode
+  • id5
+  • intentiq
+  • invisibly
+  • kargo
+  • konduit
+  • liveintent
+  • livewrapped
+  • magnite
+  • malltv
+  • medianet
+  • mobkoi
+  • nobid
+  • oolo
+  • optimon
+  • oxxion
+  • pianoDmp
+  • pubmatic
+  • pubperf
+  • pubstack
+  • pubwise
+  • pubxai
+  • pulsepoint
+  • r2b2
+  • realvu
+  • relevant
+  • roxot
+  • scaleable
+  • sharethrough
+  • sigmoid
+  • smartyads
+  • sonobi
+  • sovrn
+  • staq
+  • tercept
+  • ucfunnel
+  • uniquest
+  • yandex
+  • yieldone
+  • yuktamedia
+  • zeta_global_ssp
+
+📦 Identity Modules (62):
+------------------------------
+  • 33across
+  • admixer
+  • adquery
+  • adriver
+  • adtelligent
+  • amxrtb
+  • audienceone
+  • britepool
+  • ceeIdSystem
+  • cpexid
+  • criteo
+  • deepintent
+  • dmd
+  • euid
+  • fabrick
+  • floc
+  • freepass
+  • ftrack
+  • gravito
+  • growthcode
+  • hadron
+  • id5
+  • idplus
+  • idx
+  • imuid
+  • intentiq
+  • just
+  • kinesso
+  • liveintent
+  • lmpid
+  • lockraim
+  • lotame
+  • mediawallah
+  • merkle
+  • mobkoi
+  • mygaru
+  • navegg
+  • netid
+  • novatiq
+  • onekey
+  • open-pair
+  • pair
+  • parrable
+  • permutiveIdentityManagerIdSystem
+  • publisherlink
+  • pubmatic
+  • pubprovided
+  • quantcast
+  • ramp
+  • rewardedInterest
+  • sharedid
+  • taboola
+  • tapad
+  • teads
+  • tncIdSystem
+  • trustpid
+  • unified
+  • unified2
+  • utiq
+  • utiqMtp
+  • yahoo
+  • yandex
+
+📦 Real-Time Data Modules (60):
+------------------------------
+  • 1plusX
+  • 51Degrees
+  • a1Media
+  • aaxBlockmeter
+  • adagio
+  • adnuntius
+  • airgrid
+  • anonymised
+  • arcspan
+  • azerionedge
+  • blueconic
+  • brandmetrics
+  • browsi
+  • captify
+  • cleanio
+  • confiant
+  • contxtful
+  • dgkeyword
+  • dynamicAdBoost
+  • experian
+  • gamera
+  • geoedge
+  • geolocation
+  • goldfishAds
+  • greenbids
+  • growthCode
+  • hadron
+  • halo
+  • humansecurity
+  • ias
+  • idWard
+  • im
+  • intersection
+  • jwplayer
+  • liveIntent
+  • mediafilter
+  • medianet
+  • mgid
+  • mobian
+  • neuwo
+  • nodalsAi
+  • oneKey
+  • optable
+  • optimera
+  • overtone
+  • permutive
+  • pubmatic
+  • pubxai
+  • qortex
+  • raveltech
+  • rayn
+  • reconciliation
+  • relevad
+  • semantiq
+  • sirdata
+  • symitriDap
+  • timeout
+  • weborama
+  • wurfl
+  • zeusPrime
+
+📦 Video Modules (3):
+------------------------------
+  • adplayerpro
+  • jwplayer
+  • videojs
+
+📦 Other Modules (53):
+------------------------------
+  • adpod
+  • allowActivities
+  • anPspParamsConverter
+  • bidResponseFilter
+  • bidViewable
+  • bidViewableIO
+  • categoryTranslation
+  • consentManagementGpp
+  • consentManagementTcf
+  • consentManagementUsp
+  • currency
+  • dataControllerModule
+  • dchain
+  • debugging
+  • dfpAdpod
+  • dfp_express
+  • dfp_video
+  • dsaControl
+  • ehealthcaresolutions
+  • enrichmentLiftMeasurement
+  • floors
+  • freewheel
+  • gppControl_usnat
+  • gppControl_usstates
+  • gpt-pre-auction
+  • idLibrary
+  • index
+  • instreamTracking
+  • konduit
+  • mass
+  • multibid
+  • nativeRendering
+  • oxxionRtdProvide
+  • paapi
+  • paapiForGpt
+  • prebidServer
+  • previousAuctionInfo
+  • pubCommonId
+  • s2sTesting
+  • schain
+  • scoremedia
+  • sizeMapping
+  • sizeMappingV2
+  • spm
+  • targetVideo_video
+  • tcfControl
+  • topLevelPaapi
+  • topicsFpdModule
+  • userId
+  • validationFpdModule
+  • video
+  • viewability
+  • yieldmoSyntheticInventoryModule
+
+JSON Output:
+--------------------
+{
+  "Bid Adapters": [
+    "bidstack",
+    "dochase",
+    "exads",
+    "glomexbidder",
+    "logicad",
+    "illumin",
+    "between",
+    "jwplayer",
+    "oraki",
+    "didnavideo",
+    "bidglass",
+    "bidsxchange",
+    "iprom",
+    "dailymotion",
+    "aol",
+    "didnadisplay",
+    "luponmedia",
+    "adyoulike",
+    "programmaticX",
+    "yieldnexus",
+    "9dotsmedia",
+    "e_volution",
+    "wipes",
+    "concert",
+    "supply2",
+    "theAdx",
+    "freewheelssp",
+    "unruly",
+    "kimberlite",
+    "appush",
+    "truereach",
+    "oms",
+    "rixengine",
+    "compass",
+    "openwebxchange",
+    "exco",
+    "startio",
+    "relay",
+    "triplelift",
+    "optidigital",
+    "smoot",
+    "sharethrough",
+    "caroda",
+    "jixie",
+    "smn",
+    "xendiz",
+    "bwx",
+    "hybrid",
+    "definemedia",
+    "trustedstack",
+    "viously",
+    "greedygame",
+    "rhythmone",
+    "openxoutstream",
+    "shinezRtb",
+    "nativo",
+    "orbitsoft",
+    "lkqd",
+    "onetag",
+    "gnet",
+    "admatic",
+    "adkernelAdn",
+    "doceree",
+    "limelightDigital",
+    "adport",
+    "innity",
+    "adman",
+    "turktelekom",
+    "yieldlab",
+    "easybid",
+    "newspassid",
+    "madvertise",
+    "videoheroes",
+    "copper6ssp",
+    "ebdr",
+    "cox",
+    "retailspot",
+    "addigi",
+    "criteo",
+    "adipolo",
+    "pixfuture",
+    "kumma",
+    "richaudience",
+    "frvradn",
+    "stroeerCore",
+    "setupad",
+    "spotx",
+    "qortex",
+    "adzymic",
+    "a1media",
+    "adstir",
+    "invibes",
+    "openweb",
+    "polymorph",
+    "resetdigital",
+    "sa_lunamedia",
+    "undertone",
+    "displayio",
+    "kueez",
+    "emetriq",
+    "kubient",
+    "ras",
+    "trafficgate",
+    "giants",
+    "mgid",
+    "adverxo",
+    "ampliffy",
+    "aceex",
+    "epsilon",
+    "adsparc",
+    "pilotx",
+    "streamkey",
+    "blockthrough",
+    "evtech",
+    "otm",
+    "pangle",
+    "gxone",
+    "inmar",
+    "motionspots",
+    "lm_kiviads",
+    "bucksense",
+    "engageadx",
+    "pubgenius",
+    "smrtconnect",
+    "axis",
+    "zeta_global",
+    "prisma",
+    "xe",
+    "r2b2",
+    "pgammedia",
+    "qt",
+    "themoneytizer",
+    "yieldmo",
+    "videoreach",
+    "yobee",
+    "admixer",
+    "incrementx",
+    "videobyte",
+    "janet",
+    "optimera",
+    "escalax",
+    "interactiveOffers",
+    "openwebvideo",
+    "ias",
+    "buzzoola",
+    "pubx",
+    "waardex",
+    "pxyz",
+    "loopme",
+    "biddo",
+    "suntContent",
+    "ocm",
+    "adtrue",
+    "audiencerun",
+    "welect",
+    "movingup",
+    "mediasniper",
+    "preciso",
+    "algorix",
+    "adnow",
+    "motorik",
+    "deltaprojects",
+    "ivs",
+    "playdigo",
+    "ix",
+    "colossus",
+    "unibots",
+    "telaria",
+    "rtbsape",
+    "lane4",
+    "orangeclickmedia",
+    "widespace",
+    "unicorn",
+    "saambaa",
+    "silvermob",
+    "vidazoo",
+    "mobupps",
+    "stickyadstv",
+    "ssmas",
+    "brid",
+    "cointraffic",
+    "adpone",
+    "sparteo",
+    "epom",
+    "minutemedia",
+    "mediaeyes",
+    "onemobile",
+    "voisetech",
+    "optimatic",
+    "matomy",
+    "epomDspBidAdapter",
+    "mobfoxpb",
+    "bluebillywig",
+    "quantumdex",
+    "ad2iction",
+    "triplelift_native",
+    "selectmediavideo",
+    "microad",
+    "lunamedia",
+    "tradplus",
+    "appierGM",
+    "brave",
+    "viewdeosDX",
+    "nativery",
+    "datawrkz",
+    "gjirafa",
+    "adxcg",
+    "talkads",
+    "bedigitech",
+    "ehealthcaresolutions",
+    "sara",
+    "uniquest",
+    "targetvideo",
+    "pgam",
+    "adt",
+    "converge",
+    "duration",
+    "adomega",
+    "axonix",
+    "apstream",
+    "yieldbot",
+    "colossusssp",
+    "aniview",
+    "adtarget_org",
+    "idx",
+    "admaticde",
+    "medianet",
+    "taboola",
+    "visiblemeasures",
+    "trustxstandalone",
+    "chtnw",
+    "sovrn",
+    "proxistore",
+    "152media",
+    "optable",
+    "fluct",
+    "ads_interactive",
+    "inskin",
+    "nexverse",
+    "gourmetads",
+    "contxtful",
+    "acuityads",
+    "pulsepoint",
+    "indiecue",
+    "yahooAdvertising",
+    "adot",
+    "appier",
+    "adnuntius",
+    "admaru",
+    "cordless",
+    "lasso",
+    "smartico",
+    "pubnative",
+    "vrtcal",
+    "audiencemedia",
+    "adsinteractive",
+    "brainy",
+    "ninthdecimal",
+    "sublime",
+    "valueimpression",
+    "adasta",
+    "artechnology",
+    "iqzone",
+    "adlivetech",
+    "teal",
+    "djax",
+    "engagebdr",
+    "yeahmobi",
+    "responsiveads",
+    "madsense",
+    "nextMillennium",
+    "lemmadigital",
+    "ringieraxelspringer",
+    "valuad",
+    "featureforward",
+    "tappx",
+    "relaido",
+    "aidem",
+    "pixelpluses",
+    "freedomadnetwork",
+    "tremor",
+    "mediaConsortium",
+    "kuantyx",
+    "bidmyadz",
+    "adbutler",
+    "admixeradx",
+    "mantis",
+    "tagoras",
+    "tapnative",
+    "nextroll",
+    "mediaimpact",
+    "smilewanted",
+    "gambid",
+    "silverpush",
+    "pubrise",
+    "underdogmedia",
+    "futureads",
+    "mediakeys",
+    "smartytech",
+    "rediads",
+    "risexchange",
+    "vdoai",
+    "akcelo",
+    "pubcircle",
+    "gamoshi",
+    "rtbstack",
+    "sonic_twist",
+    "mobilefuse",
+    "stackadapt",
+    "rtbanalytica",
+    "adspirit",
+    "selectmedia",
+    "bitmedia",
+    "emtv",
+    "gmossp",
+    "advangelists",
+    "fyber",
+    "districtm",
+    "nobid",
+    "visx",
+    "outbrain_old",
+    "flipp",
+    "brightroll",
+    "smartadline",
+    "rexrtb",
+    "pollux",
+    "videonow",
+    "vimayx",
+    "adhash",
+    "globalsun",
+    "feedad",
+    "tredio",
+    "adgeneration",
+    "browsi",
+    "datablocks",
+    "fwssp",
+    "viqeo",
+    "beop",
+    "adtonos",
+    "streamlyn",
+    "ttd",
+    "krushmedia",
+    "adview",
+    "yieldone",
+    "rads",
+    "adrino",
+    "pixad",
+    "districtmdmx",
+    "bridgeupp",
+    "automatad",
+    "invamia",
+    "adhese",
+    "conceptx",
+    "aso",
+    "brainx",
+    "stellormedia",
+    "33across",
+    "eightPod",
+    "teads",
+    "rise",
+    "ix-server",
+    "rxnetwork",
+    "markapp",
+    "rubicon",
+    "bms",
+    "adtarget",
+    "adelement",
+    "edge226",
+    "mediago",
+    "pubmatic",
+    "avct",
+    "vistars",
+    "bmtm",
+    "ablida",
+    "consumable",
+    "zmaticoo",
+    "aduptech",
+    "scattered",
+    "cleanmedianet",
+    "slimcut",
+    "addefend",
+    "appstock",
+    "amx",
+    "copper6",
+    "pubtech",
+    "glimpse",
+    "astraone",
+    "bidmachine",
+    "adWMG",
+    "connektai",
+    "dspx",
+    "lunamediahb",
+    "vidoomy",
+    "andBeyondMedia",
+    "somoaudience",
+    "impactify",
+    "lifestreet",
+    "discovery",
+    "netaddiction",
+    "vuukle",
+    "embimedia",
+    "blue",
+    "jdpmedia",
+    "displayioads",
+    "mathildeads",
+    "waardex_ak",
+    "kiviads",
+    "goldbach",
+    "vungle",
+    "dianomi",
+    "adbite",
+    "tpmn",
+    "michao",
+    "mabidder",
+    "smaato",
+    "logan",
+    "dmx",
+    "justpremium",
+    "divreach",
+    "dsp_geniee",
+    "revbid",
+    "inmobi",
+    "xtrmqb",
+    "mediaforce",
+    "vlyby",
+    "ozone",
+    "metax",
+    "ucfunnel",
+    "mediabrama",
+    "bidgency",
+    "mobkoi",
+    "huaweiads",
+    "kueezrtb",
+    "programmatica",
+    "amx-server",
+    "appierExt",
+    "alkimi",
+    "admedia",
+    "greenbids",
+    "mediafuse",
+    "monetixads",
+    "rakuten",
+    "velonium",
+    "adliveplus",
+    "pagescience",
+    "a4g",
+    "gothamads",
+    "revcontent",
+    "applogy",
+    "nexx360",
+    "beachfront",
+    "adf",
+    "opsco",
+    "kobler",
+    "fairtrade",
+    "aseal",
+    "urekamedia",
+    "audienceNetwork",
+    "connectad",
+    "denakop",
+    "optout",
+    "viant",
+    "condorx",
+    "stv",
+    "insticator",
+    "sonobi",
+    "glomex",
+    "publir",
+    "jamojar",
+    "onomagic",
+    "contentignite",
+    "cpmstar",
+    "ergadx",
+    "bluesea",
+    "felixads",
+    "peak226",
+    "streamvision",
+    "zeroclickfraud",
+    "ventes",
+    "vidcrunchllc",
+    "adtelligent",
+    "vertamedia",
+    "9MediaOnline",
+    "clickforce",
+    "trafficroots",
+    "defymedia",
+    "zeta_global_ssp",
+    "screencore",
+    "driftpixel",
+    "adpartner",
+    "consumable-server",
+    "ogury",
+    "prismassp",
+    "eclickads",
+    "qwarry",
+    "projectagora",
+    "trion",
+    "adagio",
+    "smartyads",
+    "danmarket",
+    "adtrgtme",
+    "bidsmind",
+    "readpeak",
+    "pgamssp",
+    "finative",
+    "appnexus",
+    "integr8",
+    "spinx",
+    "contentexchange",
+    "oneplanetonly",
+    "rtbhouse",
+    "pwbid",
+    "adpluto",
+    "cadent_aperture_mx",
+    "oppamedia",
+    "seedingAlliance",
+    "improvedigital",
+    "opamarketplace",
+    "apester",
+    "ottadvisors",
+    "quantum",
+    "smartx",
+    "docereeadmanager",
+    "big-richmedia",
+    "monetix",
+    "adsolut",
+    "seedtag",
+    "ownadx",
+    "rocketlab",
+    "attekmi",
+    "bigoad",
+    "adquery",
+    "iqx",
+    "showheroes-bs",
+    "collectcent",
+    "avantisvideo",
+    "dexerto",
+    "uol",
+    "minutemediaplus",
+    "etarget",
+    "afp",
+    "my6sense",
+    "equativ",
+    "relevatehealth",
+    "missena",
+    "iionads",
+    "lucead",
+    "yieldlove",
+    "adkernel",
+    "aja",
+    "bidtheatre",
+    "c1x",
+    "houseofpubs",
+    "adocean",
+    "infytv",
+    "vibrantmedia",
+    "padsquad",
+    "gamma",
+    "blasto",
+    "quantcast",
+    "robusta",
+    "colombia",
+    "cwire",
+    "headbidding",
+    "iqm",
+    "operaads",
+    "mgidX",
+    "digiad",
+    "connatix",
+    "open8",
+    "eplanning",
+    "craft",
+    "huddledmasses",
+    "eskimi",
+    "yandex",
+    "engageya",
+    "snigel",
+    "adsyield",
+    "adbookpsp",
+    "stailamedia",
+    "coinzilla",
+    "hyperbrainz",
+    "viewdeos",
+    "dxkulture",
+    "mediasquare",
+    "codefuel",
+    "adpluto_dsp",
+    "headbidder",
+    "bcmint",
+    "ssp_geniee",
+    "getintent",
+    "playwire",
+    "go2net",
+    "1accord",
+    "roundel",
+    "vox",
+    "temedya",
+    "freepass",
+    "livewrapped",
+    "adriver",
+    "yieldlift",
+    "oftmedia",
+    "appierBR",
+    "kargo",
+    "adblender",
+    "omnidex",
+    "bidbuddy",
+    "marsmedia",
+    "rockyou",
+    "vidcrunch",
+    "growads",
+    "twistDigital",
+    "sspBC",
+    "distroscale",
+    "bidscube",
+    "apacdex",
+    "melozen",
+    "shinez",
+    "openx",
+    "orbidder",
+    "bridgewell",
+    "rtbdemand_com",
+    "ccx",
+    "onedisplay",
+    "loyal",
+    "adoppler",
+    "adinify",
+    "winr",
+    "deepintent",
+    "adfusion",
+    "adprime",
+    "synacormedia",
+    "imds",
+    "malltv",
+    "mytarget",
+    "pstudio",
+    "adplus",
+    "filmzie",
+    "global_sun",
+    "outbrain",
+    "smarthub",
+    "adgrid",
+    "adrelevantis",
+    "arteebee",
+    "aax",
+    "bcm",
+    "performax",
+    "redtram",
+    "lockerdome",
+    "stn",
+    "eywamedia",
+    "rxrtb",
+    "tgm",
+    "intertech",
+    "gumgum",
+    "relevantdigital",
+    "boldwin",
+    "anyclip",
+    "gridNM",
+    "holid",
+    "kidoz",
+    "adliveconnect",
+    "smartadserver",
+    "grid",
+    "beintoo",
+    "bliink",
+    "trustx",
+    "h12media",
+    "hypelab",
+    "digitalmatter"
+  ],
+  "Analytics Adapters": [
+    "konduit",
+    "adagio",
+    "generic",
+    "scaleable",
+    "smartyads",
+    "AsteriobidPbm",
+    "malltv",
+    "magnite",
+    "pubstack",
+    "medianet",
+    "yieldone",
+    "sigmoid",
+    "intentiq",
+    "roxot",
+    "livewrapped",
+    "automatad",
+    "oxxion",
+    "adkernelAdn",
+    "adWMG",
+    "oolo",
+    "invisibly",
+    "sovrn",
+    "pubwise",
+    "adloox",
+    "assertiveYield",
+    "ucfunnel",
+    "kargo",
+    "nobid",
+    "optimon",
+    "yuktamedia",
+    "asteriobid",
+    "sonobi",
+    "mobkoi",
+    "33across",
+    "eightPod",
+    "id5",
+    "staq",
+    "bidwatch",
+    "concert",
+    "tercept",
+    "liveintent",
+    "pulsepoint",
+    "advRed",
+    "eplanning",
+    "greenbids",
+    "appier",
+    "adnuntius",
+    "r2b2",
+    "yandex",
+    "growthcode",
+    "bydata",
+    "adxcg",
+    "adxpremium",
+    "browsi",
+    "relevant",
+    "pianoDmp",
+    "datablocks",
+    "finteza",
+    "pubperf",
+    "realvu",
+    "uniquest",
+    "zeta_global_ssp",
+    "audigent",
+    "ats",
+    "pubmatic",
+    "pubxai",
+    "sharethrough",
+    "agma"
+  ],
+  "Identity Modules": [
+    "deepintent",
+    "audienceone",
+    "unified",
+    "pubprovided",
+    "idx",
+    "navegg",
+    "mygaru",
+    "britepool",
+    "utiqMtp",
+    "ceeIdSystem",
+    "intentiq",
+    "novatiq",
+    "amxrtb",
+    "hadron",
+    "freepass",
+    "taboola",
+    "quantcast",
+    "trustpid",
+    "adriver",
+    "permutiveIdentityManagerIdSystem",
+    "euid",
+    "kinesso",
+    "idplus",
+    "cpexid",
+    "netid",
+    "tncIdSystem",
+    "ftrack",
+    "fabrick",
+    "utiq",
+    "mobkoi",
+    "33across",
+    "pair",
+    "id5",
+    "teads",
+    "onekey",
+    "open-pair",
+    "liveintent",
+    "merkle",
+    "dmd",
+    "publisherlink",
+    "criteo",
+    "adquery",
+    "growthcode",
+    "imuid",
+    "lotame",
+    "adtelligent",
+    "mediawallah",
+    "yandex",
+    "just",
+    "sharedid",
+    "gravito",
+    "lockraim",
+    "admixer",
+    "tapad",
+    "ramp",
+    "pubmatic",
+    "yahoo",
+    "parrable",
+    "lmpid",
+    "unified2",
+    "rewardedInterest",
+    "floc"
+  ],
+  "Real-Time Data Modules": [
+    "confiant",
+    "adagio",
+    "anonymised",
+    "intersection",
+    "dgkeyword",
+    "overtone",
+    "geoedge",
+    "1plusX",
+    "nodalsAi",
+    "weborama",
+    "geolocation",
+    "humansecurity",
+    "im",
+    "medianet",
+    "oneKey",
+    "mgid",
+    "hadron",
+    "jwplayer",
+    "raveltech",
+    "sirdata",
+    "gamera",
+    "dynamicAdBoost",
+    "mediafilter",
+    "mobian",
+    "a1Media",
+    "optable",
+    "reconciliation",
+    "arcspan",
+    "airgrid",
+    "neuwo",
+    "growthCode",
+    "permutive",
+    "aaxBlockmeter",
+    "azerionedge",
+    "blueconic",
+    "contxtful",
+    "liveIntent",
+    "captify",
+    "semantiq",
+    "timeout",
+    "zeusPrime",
+    "greenbids",
+    "idWard",
+    "adnuntius",
+    "browsi",
+    "experian",
+    "relevad",
+    "51Degrees",
+    "goldfishAds",
+    "pubmatic",
+    "pubxai",
+    "cleanio",
+    "qortex",
+    "symitriDap",
+    "halo",
+    "optimera",
+    "wurfl",
+    "brandmetrics",
+    "rayn",
+    "ias"
+  ],
+  "Video Modules": [
+    "videojs",
+    "jwplayer",
+    "adplayerpro"
+  ],
+  "Other Modules": [
+    "konduit",
+    "dataControllerModule",
+    "dfpAdpod",
+    "prebidServer",
+    "targetVideo_video",
+    "enrichmentLiftMeasurement",
+    "yieldmoSyntheticInventoryModule",
+    "anPspParamsConverter",
+    "allowActivities",
+    "video",
+    "floors",
+    "tcfControl",
+    "previousAuctionInfo",
+    "dfp_express",
+    "consentManagementTcf",
+    "spm",
+    "schain",
+    "sizeMapping",
+    "bidViewableIO",
+    "dfp_video",
+    "gppControl_usstates",
+    "nativeRendering",
+    "gppControl_usnat",
+    "idLibrary",
+    "debugging",
+    "instreamTracking",
+    "freewheel",
+    "topLevelPaapi",
+    "consentManagementGpp",
+    "sizeMappingV2",
+    "index",
+    "paapi",
+    "categoryTranslation",
+    "mass",
+    "multibid",
+    "bidResponseFilter",
+    "oxxionRtdProvide",
+    "currency",
+    "s2sTesting",
+    "topicsFpdModule",
+    "pubCommonId",
+    "ehealthcaresolutions",
+    "viewability",
+    "adpod",
+    "dsaControl",
+    "userId",
+    "bidViewable",
+    "scoremedia",
+    "dchain",
+    "consentManagementUsp",
+    "validationFpdModule",
+    "paapiForGpt",
+    "gpt-pre-auction"
+  ]
+}

--- a/prebid.js_modules_version_9.51.0.txt
+++ b/prebid.js_modules_version_9.51.0.txt
@@ -1,0 +1,1064 @@
+Repository: prebid/Prebid.js
+Version: 9.51.0
+Modules Directory: modules
+
+Prebid.js Module Categories:
+========================================
+
+📦 Bid Adapters (331):
+------------------------------
+  • 33across
+  • 360playvid
+  • BT
+  • a1Media
+  • a4g
+  • ablida
+  • acuityads
+  • ad2iction
+  • adWMG
+  • adagio
+  • adbutler
+  • addefend
+  • adf
+  • adfusion
+  • adgeneration
+  • adgrid
+  • adhash
+  • adhese
+  • adipolo
+  • adkernel
+  • adkernelAdn
+  • adman
+  • admaru
+  • admatic
+  • admedia
+  • admixer
+  • adnow
+  • adnuntius
+  • adocean
+  • adot
+  • adpartner
+  • adplus
+  • adpone
+  • adprime
+  • adquery
+  • adrelevantis
+  • adrino
+  • adriver
+  • ads_interactive
+  • adsinteractive
+  • adspirit
+  • adstir
+  • adtarget
+  • adtelligent
+  • adtrgtme
+  • adtrue
+  • aduptech
+  • advangelists
+  • adverxo
+  • adxcg
+  • adyoulike
+  • afp
+  • aidem
+  • aja
+  • akcelo
+  • alkimi
+  • ampliffy
+  • amx
+  • aniview
+  • anyclip
+  • apacdex
+  • appier
+  • appnexus
+  • appush
+  • apstream
+  • aseal
+  • aso
+  • astraone
+  • audiencerun
+  • automatad
+  • axis
+  • axonix
+  • beachfront
+  • bedigitech
+  • beop
+  • between
+  • beyondmedia
+  • biddo
+  • bidglass
+  • bidmatic
+  • bidscube
+  • bidtheatre
+  • big-richmedia
+  • bitmedia
+  • blasto
+  • bliink
+  • blue
+  • bms
+  • boldwin
+  • brainx
+  • brave
+  • brid
+  • bridgeupp
+  • bridgewell
+  • brightMountainMedia
+  • browsi
+  • bucksense
+  • buzzoola
+  • c1x
+  • cadentApertureMX
+  • caroda
+  • ccx
+  • chtnw
+  • cleanmedianet
+  • clickforce
+  • codefuel
+  • cointraffic
+  • coinzilla
+  • colombia
+  • colossusssp
+  • compass
+  • conceptx
+  • concert
+  • condorx
+  • connatix
+  • connectad
+  • consumable
+  • contentexchange
+  • contxtful
+  • conversant
+  • copper6ssp
+  • cpmstar
+  • craft
+  • criteo
+  • cwire
+  • dailyhunt
+  • dailymotion
+  • datablocks
+  • datawrkz
+  • deepintent
+  • deltaprojects
+  • dexerto
+  • dianomi
+  • digitalMatter
+  • discovery
+  • displayio
+  • distroscale
+  • djax
+  • doceree
+  • docereeAdManager
+  • dochase
+  • driftpixel
+  • dsp_geniee
+  • dspx
+  • dvgroup
+  • dxkulture
+  • e_volution
+  • eclickads
+  • edge226
+  • ehealthcaresolutions
+  • eightPod
+  • emtv
+  • engageya
+  • eplanning
+  • epomDsp
+  • equativ
+  • escalax
+  • eskimi
+  • etarget
+  • exads
+  • exco
+  • feedad
+  • finative
+  • flipp
+  • fluct
+  • freepass
+  • freewheel-ssp
+  • fwssp
+  • gamma
+  • gamoshi
+  • getintent
+  • gjirafa
+  • globalsun
+  • glomex
+  • gmossp
+  • gnet
+  • goldbach
+  • gothamads
+  • greenbids
+  • grid
+  • growadvertising
+  • gumgum
+  • h12media
+  • holid
+  • hybrid
+  • hypelab
+  • idx
+  • illumin
+  • imds
+  • impactify
+  • improvedigital
+  • incrx
+  • inmobi
+  • innity
+  • insticator
+  • integr8
+  • interactiveOffers
+  • invamia
+  • invibes
+  • iprom
+  • iqx
+  • iqzone
+  • ivs
+  • ix
+  • jixie
+  • justpremium
+  • jwplayer
+  • kargo
+  • kimberlite
+  • kiviads
+  • kobler
+  • krushmedia
+  • kubient
+  • kueez
+  • kueezRtb
+  • lane4
+  • lasso
+  • lemmaDigital
+  • lifestreet
+  • limelightDigital
+  • livewrapped
+  • lkqd
+  • lm_kiviads
+  • lockerdome
+  • logan
+  • logicad
+  • loglylift
+  • loopme
+  • loyal
+  • lucead
+  • lunamediahb
+  • luponmedia
+  • mabidder
+  • madsense
+  • madvertise
+  • malltv
+  • mantis
+  • marsmedia
+  • mathildeads
+  • mediaConsortium
+  • mediabrama
+  • mediaeyes
+  • mediaforce
+  • mediafuse
+  • mediago
+  • mediaimpact
+  • mediakeys
+  • medianet
+  • mediasniper
+  • mediasquare
+  • mgid
+  • mgidX
+  • michao
+  • microad
+  • minutemedia
+  • missena
+  • mobfoxpb
+  • mobilefuse
+  • mobkoi
+  • my6sense
+  • mytarget
+  • nativery
+  • nativo
+  • newspassid
+  • nextMillennium
+  • nextroll
+  • nexverse
+  • nexx360
+  • nobid
+  • ogury
+  • omnidex
+  • oms
+  • onetag
+  • onomagic
+  • opaMarketplace
+  • open8
+  • openweb
+  • openx
+  • operaads
+  • opsco
+  • optable
+  • optidigital
+  • optout
+  • oraki
+  • orbidder
+  • orbitsoft
+  • otm
+  • outbrain
+  • ownadx
+  • ozone
+  • padsquad
+  • pangle
+  • performax
+  • pgamssp
+  • pilotx
+  • pinkLion
+  • pixfuture
+  • playdigo
+  • preciso
+  • prisma
+  • programmaticX
+  • programmatica
+  • proxistore
+  • pstudio
+  • pubCircle
+  • pubgenius
+  • publir
+  • pubmatic
+  • pubrise
+  • pubwise
+  • pubx
+  • pulsepoint
+  • pxyz
+  • qt
+  • quantcast
+  • qwarry
+  • r2b2
+  • rads
+  • readpeak
+  • rediads
+  • redtram
+  • relaido
+  • relay
+  • relevantdigital
+  • relevatehealth
+  • resetdigital
+  • responsiveAds
+  • retailspot
+  • revcontent
+  • rhythmone
+  • richaudience
+
+📦 Analytics Adapters (51):
+------------------------------
+  • 33across
+  • AsteriobidPbm
+  • adWMG
+  • adagio
+  • adkernelAdn
+  • adloox
+  • adnuntius
+  • advRed
+  • adxcg
+  • adxpremium
+  • agma
+  • appier
+  • asteriobid
+  • ats
+  • automatad
+  • bidwatch
+  • browsi
+  • byData
+  • concert
+  • conversant
+  • datablocks
+  • eightPod
+  • finteza
+  • generic
+  • greenbids
+  • growthCode
+  • hadron
+  • id5
+  • intentIq
+  • invisibly
+  • kargo
+  • konduit
+  • liveIntent
+  • livewrapped
+  • magnite
+  • malltv
+  • medianet
+  • mobkoi
+  • nobid
+  • oolo
+  • optimon
+  • oxxion
+  • pianoDmp
+  • pubmatic
+  • pubperf
+  • pubstack
+  • pubwise
+  • pubxai
+  • pulsepoint
+  • r2b2
+  • relevant
+
+📦 Rtd Modules (54):
+------------------------------
+  • 1plusX
+  • 51Degrees
+  • a1Media
+  • aaxBlockmeter
+  • adagio
+  • adlane
+  • adloox
+  • adnuntius
+  • airgrid
+  • akamaiDap
+  • anonymised
+  • arcspan
+  • azerionedge
+  • blueconic
+  • brandmetrics
+  • browsi
+  • cleanio
+  • confiant
+  • contxtful
+  • dgkeyword
+  • dynamicAdBoost
+  • experian
+  • gamera
+  • geoedge
+  • geolocation
+  • goldfishAds
+  • greenbids
+  • growthCode
+  • hadron
+  • humansecurity
+  • ias
+  • im
+  • intersection
+  • jwplayer
+  • liveIntent
+  • mediafilter
+  • medianet
+  • mgid
+  • mobian
+  • neuwo
+  • nodalsAi
+  • oneKey
+  • optable
+  • optimera
+  • overtone
+  • oxxion
+  • permutive
+  • pubmatic
+  • pubxai
+  • qortex
+  • raveltech
+  • rayn
+  • reconciliation
+  • relevad
+
+📦 Identity Modules (48):
+------------------------------
+  • 33across
+  • admixer
+  • adquery
+  • adriver
+  • adtelligent
+  • amx
+  • cee
+  • connect
+  • criteo
+  • czechAd
+  • dac
+  • deepintentDpes
+  • dmd
+  • euid
+  • fabrick
+  • freepass
+  • ftrack
+  • gravito
+  • growthCode
+  • hadron
+  • id5
+  • identityLink
+  • idx
+  • imu
+  • intentIq
+  • just
+  • kinesso
+  • liveIntent
+  • lmp
+  • lockrAIM
+  • lotamePanorama
+  • merkle
+  • mobkoi
+  • mwOpenLink
+  • mygaru
+  • navegg
+  • net
+  • novatiq
+  • oneKey
+  • openPair
+  • operaads
+  • pair
+  • permutiveIdentityManager
+  • pubProvided
+  • publink
+  • pubmatic
+  • quantcast
+  • rewardedInterest
+
+📦 Other Modules (30):
+------------------------------
+  • adlooxAdServerVideo
+  • adplayerproVideoProvider
+  • adpod
+  • allowActivities
+  • anPspParamsConverter
+  • bidViewability
+  • bidViewabilityIO
+  • categoryTranslation
+  • consentManagementGpp
+  • consentManagementTcf
+  • consentManagementUsp
+  • currency
+  • dchain
+  • dfpAdServerVideo
+  • dfpAdpod
+  • dsaControl
+  • express
+  • fanAdapter
+  • freeWheelAdserverVideo
+  • gppControl_usnat
+  • gppControl_usstates
+  • gptPreAuction
+  • idImportLibrary
+  • instreamTracking
+  • jwplayerVideoProvider
+  • konduitWrapper
+  • nativeRendering
+  • paapi
+  • paapiForGpt
+  • priceFloors
+
+JSON Output:
+--------------------
+{
+  "bid_adapters": [
+    "33across",
+    "360playvid",
+    "BT",
+    "a1Media",
+    "a4g",
+    "ablida",
+    "acuityads",
+    "ad2iction",
+    "adWMG",
+    "adagio",
+    "adbutler",
+    "addefend",
+    "adf",
+    "adfusion",
+    "adgeneration",
+    "adgrid",
+    "adhash",
+    "adhese",
+    "adipolo",
+    "adkernelAdn",
+    "adkernel",
+    "adman",
+    "admaru",
+    "admatic",
+    "admedia",
+    "admixer",
+    "adnow",
+    "adnuntius",
+    "adocean",
+    "adot",
+    "adpartner",
+    "adplus",
+    "adpone",
+    "adprime",
+    "adquery",
+    "adrelevantis",
+    "adrino",
+    "adriver",
+    "ads_interactive",
+    "adsinteractive",
+    "adspirit",
+    "adstir",
+    "adtarget",
+    "adtelligent",
+    "adtrgtme",
+    "adtrue",
+    "aduptech",
+    "advangelists",
+    "adverxo",
+    "adxcg",
+    "adyoulike",
+    "afp",
+    "aidem",
+    "aja",
+    "akcelo",
+    "alkimi",
+    "ampliffy",
+    "amx",
+    "aniview",
+    "anyclip",
+    "apacdex",
+    "appier",
+    "appnexus",
+    "appush",
+    "apstream",
+    "aseal",
+    "aso",
+    "astraone",
+    "audiencerun",
+    "automatad",
+    "axis",
+    "axonix",
+    "beachfront",
+    "bedigitech",
+    "beop",
+    "between",
+    "beyondmedia",
+    "biddo",
+    "bidglass",
+    "bidmatic",
+    "bidscube",
+    "bidtheatre",
+    "big-richmedia",
+    "bitmedia",
+    "blasto",
+    "bliink",
+    "blue",
+    "bms",
+    "boldwin",
+    "brainx",
+    "brave",
+    "brid",
+    "bridgeupp",
+    "bridgewell",
+    "brightMountainMedia",
+    "browsi",
+    "bucksense",
+    "buzzoola",
+    "c1x",
+    "cadentApertureMX",
+    "caroda",
+    "ccx",
+    "chtnw",
+    "cleanmedianet",
+    "clickforce",
+    "codefuel",
+    "cointraffic",
+    "coinzilla",
+    "colombia",
+    "colossusssp",
+    "compass",
+    "conceptx",
+    "concert",
+    "condorx",
+    "connatix",
+    "connectad",
+    "consumable",
+    "contentexchange",
+    "contxtful",
+    "conversant",
+    "copper6ssp",
+    "cpmstar",
+    "craft",
+    "criteo",
+    "cwire",
+    "dailyhunt",
+    "dailymotion",
+    "datablocks",
+    "datawrkz",
+    "deepintent",
+    "deltaprojects",
+    "dexerto",
+    "dianomi",
+    "digitalMatter",
+    "discovery",
+    "displayio",
+    "distroscale",
+    "djax",
+    "docereeAdManager",
+    "doceree",
+    "dochase",
+    "driftpixel",
+    "dsp_geniee",
+    "dspx",
+    "dvgroup",
+    "dxkulture",
+    "e_volution",
+    "eclickads",
+    "edge226",
+    "ehealthcaresolutions",
+    "eightPod",
+    "emtv",
+    "engageya",
+    "eplanning",
+    "epomDsp",
+    "equativ",
+    "escalax",
+    "eskimi",
+    "etarget",
+    "exads",
+    "exco",
+    "feedad",
+    "finative",
+    "flipp",
+    "fluct",
+    "freepass",
+    "freewheel-ssp",
+    "fwssp",
+    "gamma",
+    "gamoshi",
+    "getintent",
+    "gjirafa",
+    "globalsun",
+    "glomex",
+    "gmossp",
+    "gnet",
+    "goldbach",
+    "gothamads",
+    "greenbids",
+    "grid",
+    "growadvertising",
+    "gumgum",
+    "h12media",
+    "holid",
+    "hybrid",
+    "hypelab",
+    "idx",
+    "illumin",
+    "imds",
+    "impactify",
+    "improvedigital",
+    "incrx",
+    "inmobi",
+    "innity",
+    "insticator",
+    "integr8",
+    "interactiveOffers",
+    "invamia",
+    "invibes",
+    "iprom",
+    "iqx",
+    "iqzone",
+    "ivs",
+    "ix",
+    "jixie",
+    "justpremium",
+    "jwplayer",
+    "kargo",
+    "kimberlite",
+    "kiviads",
+    "kobler",
+    "krushmedia",
+    "kubient",
+    "kueez",
+    "kueezRtb",
+    "lane4",
+    "lasso",
+    "lemmaDigital",
+    "lifestreet",
+    "limelightDigital",
+    "livewrapped",
+    "lkqd",
+    "lm_kiviads",
+    "lockerdome",
+    "logan",
+    "logicad",
+    "loglylift",
+    "loopme",
+    "loyal",
+    "lucead",
+    "lunamediahb",
+    "luponmedia",
+    "mabidder",
+    "madsense",
+    "madvertise",
+    "malltv",
+    "mantis",
+    "marsmedia",
+    "mathildeads",
+    "mediaConsortium",
+    "mediabrama",
+    "mediaeyes",
+    "mediaforce",
+    "mediafuse",
+    "mediago",
+    "mediaimpact",
+    "mediakeys",
+    "medianet",
+    "mediasniper",
+    "mediasquare",
+    "mgid",
+    "mgidX",
+    "michao",
+    "microad",
+    "minutemedia",
+    "missena",
+    "mobfoxpb",
+    "mobilefuse",
+    "mobkoi",
+    "my6sense",
+    "mytarget",
+    "nativery",
+    "nativo",
+    "newspassid",
+    "nextMillennium",
+    "nextroll",
+    "nexverse",
+    "nexx360",
+    "nobid",
+    "ogury",
+    "omnidex",
+    "oms",
+    "onetag",
+    "onomagic",
+    "opaMarketplace",
+    "open8",
+    "openweb",
+    "openx",
+    "operaads",
+    "opsco",
+    "optable",
+    "optidigital",
+    "optout",
+    "oraki",
+    "orbidder",
+    "orbitsoft",
+    "otm",
+    "outbrain",
+    "ownadx",
+    "ozone",
+    "padsquad",
+    "pangle",
+    "performax",
+    "pgamssp",
+    "pilotx",
+    "pinkLion",
+    "pixfuture",
+    "playdigo",
+    "preciso",
+    "prisma",
+    "programmaticX",
+    "programmatica",
+    "proxistore",
+    "pstudio",
+    "pubCircle",
+    "pubgenius",
+    "publir",
+    "pubmatic",
+    "pubrise",
+    "pubwise",
+    "pubx",
+    "pulsepoint",
+    "pxyz",
+    "qt",
+    "quantcast",
+    "qwarry",
+    "r2b2",
+    "rads",
+    "readpeak",
+    "rediads",
+    "redtram",
+    "relaido",
+    "relay",
+    "relevantdigital",
+    "relevatehealth",
+    "resetdigital",
+    "responsiveAds",
+    "retailspot",
+    "revcontent",
+    "rhythmone",
+    "richaudience"
+  ],
+  "analytics_adapters": [
+    "33across",
+    "AsteriobidPbm",
+    "adWMG",
+    "adagio",
+    "adkernelAdn",
+    "adloox",
+    "adnuntius",
+    "advRed",
+    "adxcg",
+    "adxpremium",
+    "agma",
+    "appier",
+    "asteriobid",
+    "ats",
+    "automatad",
+    "bidwatch",
+    "browsi",
+    "byData",
+    "concert",
+    "conversant",
+    "datablocks",
+    "eightPod",
+    "finteza",
+    "generic",
+    "greenbids",
+    "growthCode",
+    "hadron",
+    "id5",
+    "intentIq",
+    "invisibly",
+    "kargo",
+    "konduit",
+    "liveIntent",
+    "livewrapped",
+    "magnite",
+    "malltv",
+    "medianet",
+    "mobkoi",
+    "nobid",
+    "oolo",
+    "optimon",
+    "oxxion",
+    "pianoDmp",
+    "pubmatic",
+    "pubperf",
+    "pubstack",
+    "pubwise",
+    "pubxai",
+    "pulsepoint",
+    "r2b2",
+    "relevant"
+  ],
+  "rtd_modules": [
+    "1plusX",
+    "51Degrees",
+    "a1Media",
+    "aaxBlockmeter",
+    "adagio",
+    "adlane",
+    "adloox",
+    "adnuntius",
+    "airgrid",
+    "akamaiDap",
+    "anonymised",
+    "arcspan",
+    "azerionedge",
+    "blueconic",
+    "brandmetrics",
+    "browsi",
+    "cleanio",
+    "confiant",
+    "contxtful",
+    "dgkeyword",
+    "dynamicAdBoost",
+    "experian",
+    "gamera",
+    "geoedge",
+    "geolocation",
+    "goldfishAds",
+    "greenbids",
+    "growthCode",
+    "hadron",
+    "humansecurity",
+    "ias",
+    "im",
+    "intersection",
+    "jwplayer",
+    "liveIntent",
+    "mediafilter",
+    "medianet",
+    "mgid",
+    "mobian",
+    "neuwo",
+    "nodalsAi",
+    "oneKey",
+    "optable",
+    "optimera",
+    "overtone",
+    "oxxion",
+    "permutive",
+    "pubmatic",
+    "pubxai",
+    "qortex",
+    "raveltech",
+    "rayn",
+    "reconciliation",
+    "relevad"
+  ],
+  "identity_modules": [
+    "33across",
+    "admixer",
+    "adquery",
+    "adriver",
+    "adtelligent",
+    "amx",
+    "cee",
+    "connect",
+    "criteo",
+    "czechAd",
+    "dac",
+    "deepintentDpes",
+    "dmd",
+    "euid",
+    "fabrick",
+    "freepass",
+    "ftrack",
+    "gravito",
+    "growthCode",
+    "hadron",
+    "id5",
+    "identityLink",
+    "idx",
+    "imu",
+    "intentIq",
+    "just",
+    "kinesso",
+    "liveIntent",
+    "lmp",
+    "lockrAIM",
+    "lotamePanorama",
+    "merkle",
+    "mobkoi",
+    "mwOpenLink",
+    "mygaru",
+    "navegg",
+    "net",
+    "novatiq",
+    "oneKey",
+    "openPair",
+    "operaads",
+    "pair",
+    "permutiveIdentityManager",
+    "pubProvided",
+    "publink",
+    "pubmatic",
+    "quantcast",
+    "rewardedInterest"
+  ],
+  "other_modules": [
+    "adlooxAdServerVideo",
+    "adplayerproVideoProvider",
+    "adpod",
+    "allowActivities",
+    "anPspParamsConverter",
+    "bidViewability",
+    "bidViewabilityIO",
+    "categoryTranslation",
+    "consentManagementGpp",
+    "consentManagementTcf",
+    "consentManagementUsp",
+    "currency",
+    "dchain",
+    "dfpAdServerVideo",
+    "dfpAdpod",
+    "dsaControl",
+    "express",
+    "fanAdapter",
+    "freeWheelAdserverVideo",
+    "gppControl_usnat",
+    "gppControl_usstates",
+    "gptPreAuction",
+    "idImportLibrary",
+    "instreamTracking",
+    "jwplayerVideoProvider",
+    "konduitWrapper",
+    "nativeRendering",
+    "paapi",
+    "paapiForGpt",
+    "priceFloors"
+  ]
+}

--- a/prebid.server.go_modules_version_v3.8.0.txt
+++ b/prebid.server.go_modules_version_v3.8.0.txt
@@ -1,0 +1,499 @@
+Repository: prebid/prebid-server
+Version: v3.8.0
+
+Prebid Server Go Categories:
+========================================
+
+📦 Bid Adapters (233):
+------------------------------
+  • 33across
+  • aax
+  • aceex
+  • acuityads
+  • adapterstest
+  • adelement
+  • adf
+  • adgeneration
+  • adhese
+  • adkernel
+  • adkernelAdn
+  • adman
+  • admatic
+  • admixer
+  • adnuntius
+  • adocean
+  • adoppler
+  • adot
+  • adpone
+  • adprime
+  • adquery
+  • adrino
+  • ads interactive
+  • adsinteractive
+  • adtarget
+  • adtelligent
+  • adtonos
+  • adtrgtme
+  • advangelists
+  • adverxo
+  • adview
+  • adxcg
+  • adyoulike
+  • aidem
+  • aja
+  • algorix
+  • alkimi
+  • amx
+  • apacdex
+  • appnexus
+  • appush
+  • aso
+  • audienceNetwork
+  • automatad
+  • avocet
+  • axis
+  • axonix
+  • beachfront
+  • beintoo
+  • bematterfull
+  • between
+  • beyondmedia
+  • bidmachine
+  • bidmatic
+  • bidmyadz
+  • bidscube
+  • bidstack
+  • bigoad
+  • blasto
+  • bliink
+  • blue
+  • bluesea
+  • bmtm
+  • boldwin
+  • brave
+  • bwx
+  • cadent aperture mx
+  • ccx
+  • cointraffic
+  • coinzilla
+  • colossus
+  • compass
+  • concert
+  • connatix
+  • connectad
+  • consumable
+  • conversant
+  • copper6ssp
+  • cpmstar
+  • criteo
+  • cwire
+  • datablocks
+  • decenterads
+  • deepintent
+  • definemedia
+  • dianomi
+  • displayio
+  • dmx
+  • driftpixel
+  • dxkulture
+  • e volution
+  • edge226
+  • emtv
+  • eplanning
+  • epom
+  • escalax
+  • flipp
+  • freewheelssp
+  • frvradn
+  • gamma
+  • gamoshi
+  • globalsun
+  • gothamads
+  • grid
+  • gumgum
+  • huaweiads
+  • imds
+  • impactify
+  • improvedigital
+  • infytv
+  • inmobi
+  • insticator
+  • interactiveoffers
+  • intertech
+  • invibes
+  • iqx
+  • iqzone
+  • ix
+  • jixie
+  • kargo
+  • kayzen
+  • kidoz
+  • kiviads
+  • kobler
+  • krushmedia
+  • kueezrtb
+  • lemmadigital
+  • limelightDigital
+  • lm kiviads
+  • lockerdome
+  • logan
+  • logicad
+  • loyal
+  • lunamedia
+  • mabidder
+  • madvertise
+  • marsmedia
+  • mediago
+  • medianet
+  • melozen
+  • metax
+  • mgid
+  • mgidX
+  • minutemedia
+  • missena
+  • mobfoxpb
+  • mobilefuse
+  • motorik
+  • nativo
+  • nextmillennium
+  • nobid
+  • ogury
+  • oms
+  • onetag
+  • openweb
+  • openx
+  • operaads
+  • oraki
+  • orbidder
+  • outbrain
+  • ownadx
+  • pangle
+  • pgamssp
+  • playdigo
+  • pubmatic
+  • pubnative
+  • pubrise
+  • pulsepoint
+  • pwbid
+  • qt
+  • readpeak
+  • relevantdigital
+  • resetdigital
+  • revcontent
+  • richaudience
+  • rise
+  • roulax
+  • rtbhouse
+  • rubicon
+  • sa lunamedia
+  • screencore
+  • seedingAlliance
+  • sharethrough
+  • silvermob
+  • silverpush
+  • smaato
+  • smartadserver
+  • smarthub
+  • smartrtb
+  • smartx
+  • smartyads
+  • smilewanted
+  • smrtconnect
+  • sonobi
+  • sovrn
+  • sovrnXsp
+  • sspBC
+  • stroeerCore
+  • taboola
+  • tappx
+  • teads
+  • telaria
+  • theadx
+  • thetradedesk
+  • tpmn
+  • tradplus
+  • trafficgate
+  • triplelift
+  • triplelift native
+  • trustedstack
+  • ucfunnel
+  • undertone
+  • unicorn
+  • unruly
+  • vidazoo
+  • videobyte
+  • videoheroes
+  • vidoomy
+  • visiblemeasures
+  • visx
+  • vox
+  • vrtcal
+  • vungle
+  • xeworks
+  • yahooAds
+  • yandex
+  • yeahmobi
+  • yieldlab
+  • yieldmo
+  • yieldone
+  • zeroclickfraud
+  • zeta global ssp
+  • zmaticoo
+
+📦 Analytics Adapters (2):
+------------------------------
+  • agma
+  • pubstack
+
+📦 General Modules (2):
+------------------------------
+  • fiftyonedegrees devicedetection
+  • prebid ortb2blocking
+
+JSON Output:
+--------------------
+{
+  "Bid Adapters": [
+    "kidoz",
+    "kueezrtb",
+    "adrino",
+    "pangle",
+    "dxkulture",
+    "compass",
+    "infytv",
+    "adoppler",
+    "beintoo",
+    "frvradn",
+    "yieldmo",
+    "bidmachine",
+    "smarthub",
+    "bidscube",
+    "eplanning",
+    "grid",
+    "adgeneration",
+    "bigoad",
+    "concert",
+    "adview",
+    "revcontent",
+    "logan",
+    "coinzilla",
+    "theadx",
+    "thetradedesk",
+    "adocean",
+    "automatad",
+    "avocet",
+    "mediago",
+    "gumgum",
+    "openweb",
+    "silvermob",
+    "ccx",
+    "invibes",
+    "tpmn",
+    "pubnative",
+    "oms",
+    "e volution",
+    "bmtm",
+    "kargo",
+    "triplelift native",
+    "aso",
+    "visiblemeasures",
+    "visx",
+    "roulax",
+    "yieldone",
+    "adapterstest",
+    "aja",
+    "tappx",
+    "bliink",
+    "colossus",
+    "rubicon",
+    "gamma",
+    "adsinteractive",
+    "yandex",
+    "marsmedia",
+    "seedingAlliance",
+    "vrtcal",
+    "apacdex",
+    "playdigo",
+    "ownadx",
+    "boldwin",
+    "lockerdome",
+    "nativo",
+    "oraki",
+    "relevantdigital",
+    "bwx",
+    "smartyads",
+    "appnexus",
+    "adxcg",
+    "imds",
+    "unicorn",
+    "mabidder",
+    "flipp",
+    "bidmatic",
+    "definemedia",
+    "deepintent",
+    "mgid",
+    "telaria",
+    "vox",
+    "aceex",
+    "huaweiads",
+    "adkernel",
+    "algorix",
+    "adyoulike",
+    "beachfront",
+    "zeroclickfraud",
+    "triplelift",
+    "undertone",
+    "admatic",
+    "mobfoxpb",
+    "orbidder",
+    "loyal",
+    "yahooAds",
+    "taboola",
+    "videoheroes",
+    "resetdigital",
+    "dmx",
+    "vidoomy",
+    "metax",
+    "blasto",
+    "mgidX",
+    "adot",
+    "escalax",
+    "advangelists",
+    "adelement",
+    "insticator",
+    "gamoshi",
+    "limelightDigital",
+    "trafficgate",
+    "sovrnXsp",
+    "vidazoo",
+    "audienceNetwork",
+    "kiviads",
+    "zmaticoo",
+    "datablocks",
+    "adtrgtme",
+    "amx",
+    "acuityads",
+    "melozen",
+    "medianet",
+    "kayzen",
+    "mobilefuse",
+    "sonobi",
+    "beyondmedia",
+    "smartadserver",
+    "readpeak",
+    "cpmstar",
+    "connatix",
+    "pubrise",
+    "alkimi",
+    "adhese",
+    "minutemedia",
+    "freewheelssp",
+    "copper6ssp",
+    "epom",
+    "iqzone",
+    "appush",
+    "adf",
+    "connectad",
+    "axis",
+    "vungle",
+    "smrtconnect",
+    "sspBC",
+    "tradplus",
+    "videobyte",
+    "between",
+    "lemmadigital",
+    "gothamads",
+    "ix",
+    "pwbid",
+    "globalsun",
+    "openx",
+    "improvedigital",
+    "ads interactive",
+    "zeta global ssp",
+    "adquery",
+    "cwire",
+    "nextmillennium",
+    "sovrn",
+    "silverpush",
+    "decenterads",
+    "criteo",
+    "blue",
+    "nobid",
+    "ucfunnel",
+    "operaads",
+    "adnuntius",
+    "screencore",
+    "pgamssp",
+    "teads",
+    "inmobi",
+    "bematterfull",
+    "iqx",
+    "madvertise",
+    "displayio",
+    "adpone",
+    "adtarget",
+    "intertech",
+    "pulsepoint",
+    "ogury",
+    "dianomi",
+    "yieldlab",
+    "consumable",
+    "axonix",
+    "logicad",
+    "aax",
+    "jixie",
+    "adprime",
+    "smilewanted",
+    "xeworks",
+    "onetag",
+    "bidstack",
+    "adverxo",
+    "impactify",
+    "lunamedia",
+    "qt",
+    "cointraffic",
+    "adtonos",
+    "driftpixel",
+    "missena",
+    "unruly",
+    "aidem",
+    "kobler",
+    "33across",
+    "edge226",
+    "lm kiviads",
+    "smaato",
+    "adtelligent",
+    "cadent aperture mx",
+    "sharethrough",
+    "brave",
+    "motorik",
+    "bluesea",
+    "admixer",
+    "pubmatic",
+    "stroeerCore",
+    "richaudience",
+    "outbrain",
+    "yeahmobi",
+    "smartrtb",
+    "adman",
+    "trustedstack",
+    "sa lunamedia",
+    "interactiveoffers",
+    "krushmedia",
+    "adkernelAdn",
+    "smartx",
+    "rise",
+    "rtbhouse",
+    "bidmyadz",
+    "conversant",
+    "emtv"
+  ],
+  "Analytics Adapters": [
+    "pubstack",
+    "agma"
+  ],
+  "General Modules": [
+    "prebid ortb2blocking",
+    "fiftyonedegrees devicedetection"
+  ]
+}

--- a/prebid.server.java_modules_version_3.27.0.txt
+++ b/prebid.server.java_modules_version_3.27.0.txt
@@ -1,0 +1,514 @@
+Repository: prebid/prebid-server-java
+Version: 3.27.0
+
+Prebid Server Java Categories:
+========================================
+
+📦 Bid Adapters (230):
+------------------------------
+  • aax
+  • aceex
+  • acuityads
+  • adelement
+  • adf
+  • adgeneration
+  • adhese
+  • adkernel
+  • adkerneladn
+  • adman
+  • admatic
+  • admixer
+  • adnuntius
+  • adocean
+  • adoppler
+  • adot
+  • adpone
+  • adprime
+  • adquery
+  • adtarget
+  • adtelligent
+  • adtonos
+  • adtrgtme
+  • advangelists
+  • adverxo
+  • adview
+  • adxcg
+  • adyoulike
+  • aidem
+  • aja
+  • algorix
+  • alkimi
+  • amx
+  • apacdex
+  • appnexus
+  • appush
+  • aso
+  • audiencenetwork
+  • avocet
+  • axis
+  • axonix
+  • beachfront
+  • beintoo
+  • bematterfull
+  • between
+  • beyondmedia
+  • bidmachine
+  • bidmatic
+  • bidmyadz
+  • bidscube
+  • bidstack
+  • bigoad
+  • blasto
+  • bliink
+  • bluesea
+  • bmtm
+  • boldwin
+  • brave
+  • bwx
+  • cointraffic
+  • coinzilla
+  • colossus
+  • compass
+  • concert
+  • connatix
+  • connectad
+  • consumable
+  • copper6ssp
+  • cpmstar
+  • criteo
+  • datablocks
+  • decenterads
+  • deepintent
+  • definemedia
+  • dianomi
+  • displayio
+  • dmx
+  • driftpixel
+  • dxkulture
+  • edge226
+  • emtv
+  • emxdigital
+  • eplanning
+  • epom
+  • epsilon
+  • escalax
+  • evolution
+  • feedad
+  • flipp
+  • freewheelssp
+  • frvradn
+  • gamma
+  • gamoshi
+  • globalsun
+  • gotthamads
+  • grid
+  • gumgum
+  • huaweiads
+  • imds
+  • impactify
+  • improvedigital
+  • inmobi
+  • insticator
+  • interactiveoffers
+  • intertech
+  • invibes
+  • iqx
+  • iqzone
+  • ix
+  • jixie
+  • kargo
+  • kayzen
+  • kidoz
+  • kiviads
+  • kobler
+  • krushmedia
+  • kueezrtb
+  • lemmadigital
+  • limelightdigital
+  • lmkiviads
+  • lockerdome
+  • logan
+  • logicad
+  • loopme
+  • loyal
+  • lunamedia
+  • mabidder
+  • madvertise
+  • marsmedia
+  • mediago
+  • medianet
+  • melozen
+  • metax
+  • mgid
+  • mgidx
+  • minutemedia
+  • missena
+  • mobfoxpb
+  • mobilefuse
+  • mobkoi
+  • model
+  • motorik
+  • nextmillennium
+  • nobid
+  • ogury
+  • oms
+  • onetag
+  • openweb
+  • openx
+  • operaads
+  • oraki
+  • orbidder
+  • outbrain
+  • ownadx
+  • pangle
+  • pgamssp
+  • playdigo
+  • preciso
+  • pubmatic
+  • pubnative
+  • pubrise
+  • pulsepoint
+  • pwbid
+  • qt
+  • readpeak
+  • relevantdigital
+  • resetdigital
+  • revcontent
+  • richaudience
+  • rise
+  • roulax
+  • rtbhouse
+  • rubicon
+  • salunamedia
+  • screencore
+  • seedingAlliance
+  • seedtag
+  • sharethrough
+  • silvermob
+  • silverpush
+  • smaato
+  • smartadserver
+  • smarthub
+  • smartrtb
+  • smartx
+  • smartyads
+  • smilewanted
+  • smrtconnect
+  • sonobi
+  • sovrn
+  • sovrnxsp
+  • sspbc
+  • startio
+  • stroeercore
+  • taboola
+  • tappx
+  • teads
+  • telaria
+  • theadx
+  • thetradedesk
+  • thirtythreeacross
+  • tpmn
+  • tradplus
+  • trafficgate
+  • triplelift
+  • tripleliftnative
+  • trustedstack
+  • ucfunnel
+  • undertone
+  • unicorn
+  • unruly
+  • vidazoo
+  • videobyte
+  • videoheroes
+  • vidoomy
+  • visiblemeasures
+  • visx
+  • vox
+  • vrtcal
+  • vungle
+  • xeworks
+  • yahooads
+  • yandex
+  • yeahmobi
+  • yearxero
+  • yieldlab
+  • yieldmo
+  • yieldone
+  • zeroclickfraud
+  • zmaticoo
+
+📦 Analytics Adapters (3):
+------------------------------
+  • agma
+  • greenbids
+  • pubstack
+
+📦 General Modules (7):
+------------------------------
+  • confiant ad quality
+  • fiftyone devicedetection
+  • greenbids real time data
+  • ortb2 blocking
+  • request correction
+  • response correction
+  • richmedia filter
+
+📦 Privacy Modules (2):
+------------------------------
+  • uscustomlogic
+  • usnat
+
+JSON Output:
+--------------------
+{
+  "Bid Adapters": [
+    "admatic",
+    "mediago",
+    "adot",
+    "adman",
+    "adquery",
+    "apacdex",
+    "resetdigital",
+    "amx",
+    "screencore",
+    "globalsun",
+    "datablocks",
+    "sovrn",
+    "videoheroes",
+    "smaato",
+    "zeroclickfraud",
+    "theadx",
+    "bwx",
+    "silvermob",
+    "adkerneladn",
+    "adview",
+    "bliink",
+    "connectad",
+    "trafficgate",
+    "brave",
+    "evolution",
+    "yahooads",
+    "nobid",
+    "nextmillennium",
+    "roulax",
+    "freewheelssp",
+    "logan",
+    "minutemedia",
+    "thetradedesk",
+    "adpone",
+    "adtonos",
+    "inmobi",
+    "sharethrough",
+    "smartadserver",
+    "beintoo",
+    "beachfront",
+    "openx",
+    "tripleliftnative",
+    "richaudience",
+    "vrtcal",
+    "intertech",
+    "yandex",
+    "insticator",
+    "undertone",
+    "ucfunnel",
+    "lmkiviads",
+    "axis",
+    "seedingAlliance",
+    "bigoad",
+    "emxdigital",
+    "interactiveoffers",
+    "mabidder",
+    "model",
+    "yeahmobi",
+    "sovrnxsp",
+    "gotthamads",
+    "cpmstar",
+    "grid",
+    "definemedia",
+    "axonix",
+    "dxkulture",
+    "aja",
+    "kobler",
+    "displayio",
+    "jixie",
+    "zmaticoo",
+    "consumable",
+    "smrtconnect",
+    "flipp",
+    "adxcg",
+    "telaria",
+    "alkimi",
+    "improvedigital",
+    "oms",
+    "yieldone",
+    "frvradn",
+    "playdigo",
+    "pangle",
+    "copper6ssp",
+    "adnuntius",
+    "unruly",
+    "decenterads",
+    "impactify",
+    "mobilefuse",
+    "motorik",
+    "seedtag",
+    "vidoomy",
+    "colossus",
+    "pgamssp",
+    "melozen",
+    "readpeak",
+    "taboola",
+    "imds",
+    "yieldlab",
+    "rise",
+    "videobyte",
+    "iqx",
+    "adf",
+    "appush",
+    "oraki",
+    "escalax",
+    "adtarget",
+    "pubnative",
+    "tpmn",
+    "aidem",
+    "appnexus",
+    "gamoshi",
+    "connatix",
+    "sspbc",
+    "adyoulike",
+    "cointraffic",
+    "pubrise",
+    "between",
+    "kidoz",
+    "metax",
+    "rubicon",
+    "loopme",
+    "smartyads",
+    "pwbid",
+    "vungle",
+    "mobfoxpb",
+    "loyal",
+    "kayzen",
+    "salunamedia",
+    "visiblemeasures",
+    "criteo",
+    "pulsepoint",
+    "aax",
+    "smilewanted",
+    "feedad",
+    "mobkoi",
+    "blasto",
+    "teads",
+    "gumgum",
+    "mgid",
+    "ogury",
+    "edge226",
+    "logicad",
+    "tappx",
+    "beyondmedia",
+    "marsmedia",
+    "relevantdigital",
+    "audiencenetwork",
+    "boldwin",
+    "avocet",
+    "triplelift",
+    "yearxero",
+    "acuityads",
+    "invibes",
+    "pubmatic",
+    "orbidder",
+    "bematterfull",
+    "dianomi",
+    "admixer",
+    "algorix",
+    "eplanning",
+    "adtelligent",
+    "silverpush",
+    "outbrain",
+    "unicorn",
+    "yieldmo",
+    "aso",
+    "compass",
+    "openweb",
+    "lockerdome",
+    "limelightdigital",
+    "concert",
+    "bluesea",
+    "smartrtb",
+    "adgeneration",
+    "bidmachine",
+    "vidazoo",
+    "kargo",
+    "smarthub",
+    "qt",
+    "smartx",
+    "bidstack",
+    "epsilon",
+    "krushmedia",
+    "ownadx",
+    "tradplus",
+    "adocean",
+    "onetag",
+    "visx",
+    "revcontent",
+    "adkernel",
+    "trustedstack",
+    "ix",
+    "advangelists",
+    "coinzilla",
+    "madvertise",
+    "huaweiads",
+    "adhese",
+    "bidmatic",
+    "kueezrtb",
+    "deepintent",
+    "vox",
+    "adprime",
+    "gamma",
+    "bmtm",
+    "missena",
+    "adelement",
+    "xeworks",
+    "medianet",
+    "startio",
+    "lemmadigital",
+    "emtv",
+    "kiviads",
+    "preciso",
+    "mgidx",
+    "adoppler",
+    "stroeercore",
+    "bidmyadz",
+    "dmx",
+    "iqzone",
+    "epom",
+    "lunamedia",
+    "bidscube",
+    "driftpixel",
+    "operaads",
+    "sonobi",
+    "thirtythreeacross",
+    "aceex",
+    "adverxo",
+    "rtbhouse",
+    "adtrgtme"
+  ],
+  "Analytics Adapters": [
+    "greenbids",
+    "pubstack",
+    "agma"
+  ],
+  "General Modules": [
+    "richmedia filter",
+    "greenbids real time data",
+    "response correction",
+    "request correction",
+    "ortb2 blocking",
+    "confiant ad quality",
+    "fiftyone devicedetection"
+  ],
+  "Privacy Modules": [
+    "usnat",
+    "uscustomlogic"
+  ]
+}

--- a/src/repo_modules_by_version/config.py
+++ b/src/repo_modules_by_version/config.py
@@ -24,6 +24,11 @@ class RepoConfig:
     )
     modules_path: str | None = None  # Optional path to modules directory for parsing
     paths: dict[str, str] | None = None  # Multiple paths for multi-directory parsing
+    fetch_strategy: str = (
+        "full_content"  # How to fetch data: "full_content", "filenames_only", "directory_names"
+    )
+    version_override: str | None = None  # Force specific version (e.g., "master")
+    output_filename_slug: str | None = None  # Custom slug for auto-generated filenames
 
 
 def _load_repos() -> dict[str, dict]:

--- a/src/repo_modules_by_version/config.py
+++ b/src/repo_modules_by_version/config.py
@@ -16,10 +16,14 @@ class RepoConfig:
     """Configuration for a repository parser."""
 
     repo: str  # GitHub repo in format "owner/repo"
-    directory: str  # Directory within repo to parse
     description: str  # Human-readable description
     versions: list[str]  # Available versions/tags/branches
     parser_type: str = "default"  # Parser type identifier
+    directory: str | None = (
+        None  # Directory within repo to parse (for backward compatibility)
+    )
+    modules_path: str | None = None  # Optional path to modules directory for parsing
+    paths: dict[str, str] | None = None  # Multiple paths for multi-directory parsing
 
 
 def _load_repos() -> dict[str, dict]:
@@ -55,10 +59,12 @@ def get_repo_config_with_versions(name: str) -> RepoConfig:
         # Create new config with dynamic versions
         return RepoConfig(
             repo=config.repo,
-            directory=config.directory,
             description=config.description,
             versions=dynamic_versions,
             parser_type=config.parser_type,
+            directory=config.directory,
+            modules_path=config.modules_path,
+            paths=config.paths,
         )
     except Exception:
         # Return original config with fallback versions if discovery fails

--- a/src/repo_modules_by_version/github_client.py
+++ b/src/repo_modules_by_version/github_client.py
@@ -134,6 +134,22 @@ class GitHubClient:
                 f"Could not find reference '{version}' in repository"
             ) from e
 
+    def _handle_github_exception(self, e: GithubException, directory: str) -> None:
+        """
+        Handle GitHub API exceptions consistently across fetch methods.
+
+        Args:
+            e: The GitHub exception to handle
+            directory: The directory path that caused the exception
+
+        Raises:
+            Exception: Wrapped exception with appropriate error message
+        """
+        if e.status == 404:
+            raise Exception(f"Directory '{directory}' not found in repository") from e
+        else:
+            raise Exception(f"GitHub API error: {e}") from e
+
     def _fetch_directory_filenames(
         self,
         repo: Repository,
@@ -176,12 +192,7 @@ class GitHubClient:
                 # Skip subdirectories for modules parsing (we only want root level files)
 
         except GithubException as e:
-            if e.status == 404:
-                raise Exception(
-                    f"Directory '{directory}' not found in repository"
-                ) from e
-            else:
-                raise Exception(f"GitHub API error: {e}") from e
+            self._handle_github_exception(e, directory)
 
         return files_data
 
@@ -232,12 +243,7 @@ class GitHubClient:
                             pass
 
         except GithubException as e:
-            if e.status == 404:
-                raise Exception(
-                    f"Directory '{directory}' not found in repository"
-                ) from e
-            else:
-                raise Exception(f"GitHub API error: {e}") from e
+            self._handle_github_exception(e, directory)
 
         return directories_data
 
@@ -274,12 +280,7 @@ class GitHubClient:
                     files_data[content.path] = ""
 
         except GithubException as e:
-            if e.status == 404:
-                raise Exception(
-                    f"Directory '{directory}' not found in repository"
-                ) from e
-            else:
-                raise Exception(f"GitHub API error: {e}") from e
+            self._handle_github_exception(e, directory)
 
         return files_data
 

--- a/src/repo_modules_by_version/github_client.py
+++ b/src/repo_modules_by_version/github_client.py
@@ -29,15 +29,22 @@ class GitHubClient:
         self.cache_manager = VersionCacheManager()
 
     def fetch_repository_data(
-        self, repo_name: str, version: str, directory: str
+        self,
+        repo_name: str,
+        version: str,
+        directory: str | None = None,
+        modules_path: str | None = None,
+        paths: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """
-        Fetch repository data for a specific version and directory.
+        Fetch repository data for a specific version and directory/directories.
 
         Args:
             repo_name: Repository name in format "owner/repo"
             version: Git reference (tag, branch, commit SHA)
-            directory: Directory path within repository
+            directory: Directory path within repository (for backward compatibility)
+            modules_path: Optional additional directory path for modules
+            paths: Dictionary of category names to directory paths (for multi-directory parsing)
 
         Returns:
             Dictionary containing file paths and content
@@ -48,13 +55,51 @@ class GitHubClient:
             # Get the commit/reference
             ref = self._get_reference(repo, version)
 
-            # Fetch directory contents
-            files_data = self._fetch_directory_contents(repo, directory, ref)
+            # Handle multi-path fetching for new parsers like prebid-server
+            if paths:
+                paths_data = {}
+                all_files = {}
+                total_files = 0
+
+                for path in paths.values():
+                    # For multi-path parsing, fetch directory names or file names depending on repo
+                    if repo_name == "prebid/prebid.github.io":
+                        # For docs repo, we need file names not directory names
+                        path_items = self._fetch_file_names(repo, path, ref)
+                    else:
+                        # For other repos, fetch directory names (much faster)
+                        path_items = self._fetch_directory_names(repo, path, ref)
+                    paths_data[path] = path_items
+                    all_files.update(path_items)
+                    total_files += len(path_items)
+
+                return {
+                    "repo": repo_name,
+                    "version": version,
+                    "paths": paths_data,
+                    "files": all_files,
+                    "metadata": {"commit_sha": ref, "total_files": total_files},
+                }
+
+            # Handle legacy single directory/modules_path
+            target_directory = modules_path if modules_path else directory
+
+            if not target_directory:
+                raise Exception("No directory specified for repository parsing")
+
+            if modules_path:
+                # For modules parsing, only fetch filenames (much faster)
+                files_data = self._fetch_directory_filenames(
+                    repo, target_directory, ref, [".js"]
+                )
+            else:
+                # For regular parsing, fetch full content
+                files_data = self._fetch_directory_contents(repo, target_directory, ref)
 
             return {
                 "repo": repo_name,
                 "version": version,
-                "directory": directory,
+                "directory": target_directory,
                 "files": files_data,
                 "metadata": {"commit_sha": ref, "total_files": len(files_data)},
             }
@@ -89,11 +134,170 @@ class GitHubClient:
                 f"Could not find reference '{version}' in repository"
             ) from e
 
-    def _fetch_directory_contents(
-        self, repo: Repository, directory: str, ref: str
+    def _fetch_directory_filenames(
+        self,
+        repo: Repository,
+        directory: str,
+        ref: str,
+        file_extensions: list[str] | None = None,
     ) -> dict[str, str]:
         """
-        Recursively fetch all files from a directory.
+        Fetch only filenames from a directory without content (for modules parsing).
+
+        Args:
+            repo: GitHub repository object
+            directory: Directory path to fetch from
+            ref: Git reference (commit SHA, branch, tag)
+            file_extensions: Optional list of file extensions to filter (e.g., ['.js', '.py'])
+
+        Returns:
+            Dictionary mapping file paths to empty strings (for compatibility)
+        """
+        files_data = {}
+
+        try:
+            contents = repo.get_contents(directory, ref=ref)
+
+            # Handle single file case
+            if not isinstance(contents, list):
+                contents = [contents]
+
+            for content in contents:
+                if content.type == "file":
+                    # Check file extension filter
+                    if file_extensions:
+                        if not any(
+                            content.name.endswith(ext) for ext in file_extensions
+                        ):
+                            continue  # Skip files that don't match the extension filter
+
+                    # Only store filename, no content (much faster)
+                    files_data[content.path] = ""
+                # Skip subdirectories for modules parsing (we only want root level files)
+
+        except GithubException as e:
+            if e.status == 404:
+                raise Exception(
+                    f"Directory '{directory}' not found in repository"
+                ) from e
+            else:
+                raise Exception(f"GitHub API error: {e}") from e
+
+        return files_data
+
+    def _fetch_directory_names(
+        self,
+        repo: Repository,
+        directory: str,
+        ref: str,
+    ) -> dict[str, str]:
+        """
+        Fetch subdirectory names up to 2 levels deep (for structure parsing).
+
+        Args:
+            repo: GitHub repository object
+            directory: Directory path to fetch from
+            ref: Git reference (commit SHA, branch, tag)
+
+        Returns:
+            Dictionary mapping directory paths to empty strings (for compatibility)
+        """
+        directories_data = {}
+
+        try:
+            # Get first level directories
+            contents = repo.get_contents(directory, ref=ref)
+
+            # Handle single file case
+            if not isinstance(contents, list):
+                contents = [contents]
+
+            for content in contents:
+                if content.type == "dir":
+                    # Store first level directory
+                    directories_data[content.path] = ""
+
+                    # Get second level directories for modules (needed for fiftyonedegrees/devicedetection)
+                    if directory == "modules":
+                        try:
+                            sub_contents = repo.get_contents(content.path, ref=ref)
+                            if not isinstance(sub_contents, list):
+                                sub_contents = [sub_contents]
+
+                            for sub_content in sub_contents:
+                                if sub_content.type == "dir":
+                                    directories_data[sub_content.path] = ""
+                        except GithubException:
+                            # If subdirectory can't be accessed, skip it
+                            pass
+
+        except GithubException as e:
+            if e.status == 404:
+                raise Exception(
+                    f"Directory '{directory}' not found in repository"
+                ) from e
+            else:
+                raise Exception(f"GitHub API error: {e}") from e
+
+        return directories_data
+
+    def _fetch_file_names(
+        self,
+        repo: Repository,
+        directory: str,
+        ref: str,
+    ) -> dict[str, str]:
+        """
+        Fetch only file names from a directory (for documentation parsing).
+
+        Args:
+            repo: GitHub repository object
+            directory: Directory path to fetch from
+            ref: Git reference (commit SHA, branch, tag)
+
+        Returns:
+            Dictionary mapping file paths to empty strings (for compatibility)
+        """
+        files_data = {}
+
+        try:
+            # Get files from directory
+            contents = repo.get_contents(directory, ref=ref)
+
+            # Handle single file case
+            if not isinstance(contents, list):
+                contents = [contents]
+
+            for content in contents:
+                if content.type == "file":
+                    # Store file name/path with empty content
+                    files_data[content.path] = ""
+
+        except GithubException as e:
+            if e.status == 404:
+                raise Exception(
+                    f"Directory '{directory}' not found in repository"
+                ) from e
+            else:
+                raise Exception(f"GitHub API error: {e}") from e
+
+        return files_data
+
+    def _fetch_directory_contents(
+        self,
+        repo: Repository,
+        directory: str,
+        ref: str,
+        file_extensions: list[str] | None = None,
+    ) -> dict[str, str]:
+        """
+        Recursively fetch files from a directory, optionally filtered by extensions.
+
+        Args:
+            repo: GitHub repository object
+            directory: Directory path to fetch from
+            ref: Git reference (commit SHA, branch, tag)
+            file_extensions: Optional list of file extensions to filter (e.g., ['.js', '.py'])
 
         Returns:
             Dictionary mapping file paths to their content
@@ -109,13 +313,20 @@ class GitHubClient:
 
             for content in contents:
                 if content.type == "file":
+                    # Check file extension filter
+                    if file_extensions:
+                        if not any(
+                            content.name.endswith(ext) for ext in file_extensions
+                        ):
+                            continue  # Skip files that don't match the extension filter
+
                     # Fetch file content
                     file_content = self._get_file_content(content)
                     files_data[content.path] = file_content
                 elif content.type == "dir":
                     # Recursively fetch subdirectory
                     subdir_files = self._fetch_directory_contents(
-                        repo, content.path, ref
+                        repo, content.path, ref, file_extensions
                     )
                     files_data.update(subdir_files)
 

--- a/src/repo_modules_by_version/parser_factory.py
+++ b/src/repo_modules_by_version/parser_factory.py
@@ -485,17 +485,29 @@ class PrebidDocsParser(BaseParser):
                         adapters.add(adapter_name)
             categories["Bid Adapters"] = list(adapters)
 
-        elif category_name == "Analytics Adapters" and path == "dev-docs/analytics":
-            # For analytics path, get file names (remove .md extension)
+        elif category_name == "Analytics Adapters":
+            # Handle analytics adapters from different paths
             analytics = set()
             for file_path in files.keys():
                 parts = file_path.split("/")
                 if len(parts) > 0:
                     file_name = parts[-1]  # Get the file name
                     if file_name.endswith(".md"):
-                        adapter_name = file_name[:-3]  # Remove .md extension
-                        analytics.add(adapter_name)
-            categories["Analytics Adapters"] = list(analytics)
+                        base_name = file_name[:-3]  # Remove .md extension
+
+                        # Handle different analytics adapter types based on path
+                        if path == "dev-docs/modules" and base_name.endswith(
+                            "AnalyticsAdapter"
+                        ):
+                            # For modules path, remove AnalyticsAdapter suffix
+                            clean_name = base_name[:-16]  # Remove "AnalyticsAdapter"
+                            analytics.add(clean_name)
+                        elif path != "dev-docs/modules":
+                            # For dedicated analytics path, use the base name as-is
+                            analytics.add(base_name)
+
+            if analytics:
+                categories["Analytics Adapters"] = list(analytics)
 
         elif category_name == "Identity Modules":
             # For userid-submodules path, get file names (remove .md extension)
@@ -516,7 +528,6 @@ class PrebidDocsParser(BaseParser):
         ):
             # For modules path, categorize by file endings
             rtd_modules = set()
-            analytics_modules = set()
             video_modules = set()
             other_modules = set()
 
@@ -531,9 +542,6 @@ class PrebidDocsParser(BaseParser):
                         if base_name.endswith("RtdProvider"):
                             clean_name = base_name[:-11]  # Remove "RtdProvider"
                             rtd_modules.add(clean_name)
-                        elif base_name.endswith("AnalyticsAdapter"):
-                            clean_name = base_name[:-16]  # Remove "AnalyticsAdapter"
-                            analytics_modules.add(clean_name)
                         elif base_name.endswith("VideoProvider"):
                             clean_name = base_name[:-13]  # Remove "VideoProvider"
                             video_modules.add(clean_name)
@@ -543,12 +551,6 @@ class PrebidDocsParser(BaseParser):
             # Only add categories that have items and match the current category being processed
             if category_name == "Real-Time Data Modules" and rtd_modules:
                 categories["Real-Time Data Modules"] = list(rtd_modules)
-            elif category_name == "Analytics Adapters" and analytics_modules:
-                # Merge with existing analytics adapters if any
-                existing = categories.get("Analytics Adapters", [])
-                categories["Analytics Adapters"] = list(
-                    set(existing + list(analytics_modules))
-                )
             elif category_name == "Video Modules" and video_modules:
                 categories["Video Modules"] = list(video_modules)
             elif category_name == "Other Modules" and other_modules:

--- a/src/repo_modules_by_version/parser_factory.py
+++ b/src/repo_modules_by_version/parser_factory.py
@@ -149,6 +149,414 @@ class OpenAPIParser(BaseParser):
         return "\n".join(result)
 
 
+class PrebidJSParser(BaseParser):
+    """Parser specifically for Prebid.js modules directory to categorize adapters."""
+
+    def parse(self, data: dict[str, Any]) -> str:
+        """Parse Prebid.js modules and categorize by adapter type."""
+        result = []
+        result.append(f"Repository: {data['repo']}")
+        result.append(f"Version: {data['version']}")
+        result.append(f"Modules Directory: {data['directory']}")
+        result.append("")
+
+        # Categorize modules
+        modules = self._categorize_modules(data["files"])
+
+        # Display categories
+        result.append("Prebid.js Module Categories:")
+        result.append("=" * 40)
+        result.append("")
+
+        for category, files in modules.items():
+            if files:
+                result.append(
+                    f"📦 {category.replace('_', ' ').title()} ({len(files)}):"
+                )
+                result.append("-" * 30)
+                for file in sorted(files):
+                    result.append(f"  • {file}")
+                result.append("")
+
+        # Add JSON output
+        result.append("JSON Output:")
+        result.append("-" * 20)
+        import json
+
+        result.append(json.dumps(modules, indent=2))
+
+        return "\n".join(result)
+
+    def _categorize_modules(self, files: dict[str, str]) -> dict[str, list[str]]:
+        """Categorize .js files by adapter type."""
+        categories: dict[str, list[str]] = {
+            "bid_adapters": [],
+            "analytics_adapters": [],
+            "rtd_modules": [],
+            "identity_modules": [],
+            "other_modules": [],
+        }
+
+        for file_path, _ in files.items():
+            # Only process .js files in the root of modules directory
+            if not file_path.endswith(".js"):
+                continue
+
+            # Extract just the filename without path
+            filename = file_path.split("/")[-1]
+
+            # Skip if it's in a subdirectory (we only want root level files)
+            if "/" in file_path.replace("modules/", ""):
+                continue
+
+            # Categorize based on filename patterns
+            if filename.endswith("BidAdapter.js"):
+                adapter_name = filename.replace("BidAdapter.js", "")
+                categories["bid_adapters"].append(adapter_name)
+            elif filename.endswith("AnalyticsAdapter.js"):
+                adapter_name = filename.replace("AnalyticsAdapter.js", "")
+                categories["analytics_adapters"].append(adapter_name)
+            elif filename.endswith("RtdProvider.js"):
+                module_name = filename.replace("RtdProvider.js", "")
+                categories["rtd_modules"].append(module_name)
+            elif filename.endswith("IdSystem.js"):
+                system_name = filename.replace("IdSystem.js", "")
+                categories["identity_modules"].append(system_name)
+            else:
+                # Other .js modules
+                module_name = filename.replace(".js", "")
+                categories["other_modules"].append(module_name)
+
+        return categories
+
+
+class PrebidServerGoParser(BaseParser):
+    """Parser specifically for Prebid Server Go implementation to categorize adapters and modules."""
+
+    def parse(self, data: dict[str, Any]) -> str:
+        """Parse Prebid Server Go directories and categorize by type."""
+        result = []
+        result.append(f"Repository: {data['repo']}")
+        result.append(f"Version: {data['version']}")
+        result.append("")
+
+        # Parse each configured path
+        all_categories = {}
+        paths = self.config.paths or {}
+
+        for category_name, path in paths.items():
+            path_data = data.get("paths", {}).get(path, {})
+            if path_data:
+                categories = self._categorize_by_path(category_name, path, path_data)
+                all_categories.update(categories)
+
+        # Display categories
+        result.append("Prebid Server Go Categories:")
+        result.append("=" * 40)
+        result.append("")
+
+        for category, items in all_categories.items():
+            if items:
+                result.append(f"📦 {category} ({len(items)}):")
+                result.append("-" * 30)
+                for item in sorted(items):
+                    result.append(f"  • {item}")
+                result.append("")
+
+        # Add JSON output
+        result.append("JSON Output:")
+        result.append("-" * 20)
+        import json
+
+        result.append(json.dumps(all_categories, indent=2))
+
+        return "\n".join(result)
+
+    def _categorize_by_path(
+        self, category_name: str, path: str, files: dict[str, str]
+    ) -> dict[str, list[str]]:
+        """Categorize items based on the path type."""
+        categories: dict[str, list[str]] = {}
+
+        if category_name == "Bid Adapters":
+            # For adapters path, get directory names (subdirectories of adapters/)
+            adapters = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 1:  # Should be like "adapters/33across"
+                    adapter_name = parts[1]  # Get the adapter name, not "adapters"
+                    # Convert underscores to spaces
+                    adapter_name = adapter_name.replace("_", " ")
+                    adapters.add(adapter_name)
+            categories["Bid Adapters"] = list(adapters)
+
+        elif category_name == "Analytics Adapters":
+            # For analytics path, get directory names excluding specified ones
+            excluded = {"build", "clients", "filesystem"}
+            analytics = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 1:  # Should be like "analytics/pubstack"
+                    adapter_name = parts[1]  # Get the adapter name, not "analytics"
+                    if adapter_name not in excluded:
+                        # Convert underscores to spaces
+                        adapter_name = adapter_name.replace("_", " ")
+                        analytics.add(adapter_name)
+            categories["Analytics Adapters"] = list(analytics)
+
+        elif category_name == "General Modules":
+            # For modules path, get directories with subdirectories and combine names
+            modules = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                # Only include paths that have at least 3 levels (modules/dir/subdir)
+                # This ensures we only get directories that have subdirectories
+                if len(parts) >= 3:
+                    # Combine first two directory levels after "modules"
+                    # e.g., "modules/fiftyonedegrees/devicedetection" -> "fiftyonedegrees devicedetection"
+                    module_name = f"{parts[1]} {parts[2]}"
+                    modules.add(module_name)
+            categories["General Modules"] = list(modules)
+
+        return categories
+
+
+class PrebidServerJavaParser(BaseParser):
+    """Parser specifically for Prebid Server Java implementation to categorize adapters and modules."""
+
+    def parse(self, data: dict[str, Any]) -> str:
+        """Parse Prebid Server Java directories and categorize by type."""
+        result = []
+        result.append(f"Repository: {data['repo']}")
+        result.append(f"Version: {data['version']}")
+        result.append("")
+
+        # Parse each configured path
+        all_categories = {}
+        paths = self.config.paths or {}
+
+        for category_name, path in paths.items():
+            path_data = data.get("paths", {}).get(path, {})
+            if path_data:
+                categories = self._categorize_by_path(category_name, path, path_data)
+                all_categories.update(categories)
+
+        # Display categories
+        result.append("Prebid Server Java Categories:")
+        result.append("=" * 40)
+        result.append("")
+
+        for category, items in all_categories.items():
+            if items:
+                result.append(f"📦 {category} ({len(items)}):")
+                result.append("-" * 30)
+                for item in sorted(items):
+                    result.append(f"  • {item}")
+                result.append("")
+
+        # Add JSON output
+        result.append("JSON Output:")
+        result.append("-" * 20)
+        import json
+
+        result.append(json.dumps(all_categories, indent=2))
+
+        return "\n".join(result)
+
+    def _categorize_by_path(
+        self, category_name: str, path: str, files: dict[str, str]
+    ) -> dict[str, list[str]]:
+        """Categorize items based on the path type."""
+        categories: dict[str, list[str]] = {}
+
+        if category_name == "Bid Adapters":
+            # For bidder path, get directory names (subdirectories of bidder/)
+            adapters = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if (
+                    len(parts) > 1
+                ):  # Should be like "src/main/java/org/prebid/server/bidder/adapter_name"
+                    adapter_name = parts[-1]  # Get the last part (adapter name)
+                    adapters.add(adapter_name)
+            categories["Bid Adapters"] = list(adapters)
+
+        elif category_name == "Analytics Adapters":
+            # For analytics path, get directory names excluding specified ones
+            excluded = {"log"}
+            analytics = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if (
+                    len(parts) > 1
+                ):  # Should be like "src/main/java/org/prebid/server/analytics/reporter/adapter_name"
+                    adapter_name = parts[-1]  # Get the last part (adapter name)
+                    if adapter_name not in excluded:
+                        analytics.add(adapter_name)
+            categories["Analytics Adapters"] = list(analytics)
+
+        elif category_name == "General Modules":
+            # For modules path, get directory names and format them
+            modules = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 1:  # Should be like "extra/modules/module_name"
+                    module_name = parts[-1]  # Get the last part (module name)
+                    # Replace `-` with space
+                    formatted_name = module_name.replace("-", " ")
+                    # Remove "pb-" prefix if present
+                    if formatted_name.startswith("pb "):
+                        formatted_name = formatted_name[3:]  # Remove "pb "
+                    modules.add(formatted_name)
+            categories["General Modules"] = list(modules)
+
+        elif category_name == "Privacy Modules":
+            # For privacy path, get directory names
+            privacy = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if (
+                    len(parts) > 1
+                ):  # Should be like "src/main/java/org/prebid/server/activity/infrastructure/privacy/module_name"
+                    module_name = parts[-1]  # Get the last part (module name)
+                    privacy.add(module_name)
+            categories["Privacy Modules"] = list(privacy)
+
+        return categories
+
+
+class PrebidDocsParser(BaseParser):
+    """Parser specifically for Prebid Documentation site to categorize adapters and modules from documentation files."""
+
+    def parse(self, data: dict[str, Any]) -> str:
+        """Parse Prebid Documentation files and categorize by type."""
+        result = []
+        result.append(f"Repository: {data['repo']}")
+        result.append(f"Version: {data['version']}")
+        result.append("")
+
+        # Parse each configured path
+        all_categories = {}
+        paths = self.config.paths or {}
+
+        for category_name, path in paths.items():
+            path_data = data.get("paths", {}).get(path, {})
+            if path_data:
+                categories = self._categorize_by_path(category_name, path, path_data)
+                all_categories.update(categories)
+
+        # Display categories
+        result.append("Prebid Documentation Categories:")
+        result.append("=" * 40)
+        result.append("")
+
+        for category, items in all_categories.items():
+            if items:
+                result.append(f"📦 {category} ({len(items)}):")
+                result.append("-" * 30)
+                for item in sorted(items):
+                    result.append(f"  • {item}")
+                result.append("")
+
+        # Add JSON output
+        result.append("JSON Output:")
+        result.append("-" * 20)
+        import json
+
+        result.append(json.dumps(all_categories, indent=2))
+
+        return "\n".join(result)
+
+    def _categorize_by_path(
+        self, category_name: str, path: str, files: dict[str, str]
+    ) -> dict[str, list[str]]:
+        """Categorize items based on the path type."""
+        categories: dict[str, list[str]] = {}
+
+        if category_name == "Bid Adapters":
+            # For bidders path, get file names (remove .md extension)
+            adapters = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 0:
+                    file_name = parts[-1]  # Get the file name
+                    if file_name.endswith(".md"):
+                        adapter_name = file_name[:-3]  # Remove .md extension
+                        adapters.add(adapter_name)
+            categories["Bid Adapters"] = list(adapters)
+
+        elif category_name == "Analytics Adapters" and path == "dev-docs/analytics":
+            # For analytics path, get file names (remove .md extension)
+            analytics = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 0:
+                    file_name = parts[-1]  # Get the file name
+                    if file_name.endswith(".md"):
+                        adapter_name = file_name[:-3]  # Remove .md extension
+                        analytics.add(adapter_name)
+            categories["Analytics Adapters"] = list(analytics)
+
+        elif category_name == "Identity Modules":
+            # For userid-submodules path, get file names (remove .md extension)
+            identity = set()
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 0:
+                    file_name = parts[-1]  # Get the file name
+                    if file_name.endswith(".md"):
+                        module_name = file_name[:-3]  # Remove .md extension
+                        identity.add(module_name)
+            categories["Identity Modules"] = list(identity)
+
+        elif (
+            category_name
+            in ["Real-Time Data Modules", "Video Modules", "Other Modules"]
+            and path == "dev-docs/modules"
+        ):
+            # For modules path, categorize by file endings
+            rtd_modules = set()
+            analytics_modules = set()
+            video_modules = set()
+            other_modules = set()
+
+            for file_path in files.keys():
+                parts = file_path.split("/")
+                if len(parts) > 0:
+                    file_name = parts[-1]  # Get the file name
+                    if file_name.endswith(".md"):
+                        base_name = file_name[:-3]  # Remove .md extension
+
+                        # Remove redundant endings and categorize
+                        if base_name.endswith("RtdProvider"):
+                            clean_name = base_name[:-11]  # Remove "RtdProvider"
+                            rtd_modules.add(clean_name)
+                        elif base_name.endswith("AnalyticsAdapter"):
+                            clean_name = base_name[:-16]  # Remove "AnalyticsAdapter"
+                            analytics_modules.add(clean_name)
+                        elif base_name.endswith("VideoProvider"):
+                            clean_name = base_name[:-13]  # Remove "VideoProvider"
+                            video_modules.add(clean_name)
+                        else:
+                            other_modules.add(base_name)
+
+            # Only add categories that have items and match the current category being processed
+            if category_name == "Real-Time Data Modules" and rtd_modules:
+                categories["Real-Time Data Modules"] = list(rtd_modules)
+            elif category_name == "Analytics Adapters" and analytics_modules:
+                # Merge with existing analytics adapters if any
+                existing = categories.get("Analytics Adapters", [])
+                categories["Analytics Adapters"] = list(
+                    set(existing + list(analytics_modules))
+                )
+            elif category_name == "Video Modules" and video_modules:
+                categories["Video Modules"] = list(video_modules)
+            elif category_name == "Other Modules" and other_modules:
+                categories["Other Modules"] = list(other_modules)
+
+        return categories
+
+
 class ParserFactory:
     """Factory for creating appropriate parsers based on configuration."""
 
@@ -156,6 +564,10 @@ class ParserFactory:
         "default": DefaultParser,
         "markdown": MarkdownParser,
         "openapi": OpenAPIParser,
+        "prebid_js": PrebidJSParser,
+        "prebid_server_go": PrebidServerGoParser,
+        "prebid_server_java": PrebidServerJavaParser,
+        "prebid_docs": PrebidDocsParser,
     }
 
     def get_parser(self, config: RepoConfig) -> BaseParser:

--- a/src/repo_modules_by_version/repos.json
+++ b/src/repo_modules_by_version/repos.json
@@ -4,27 +4,44 @@
         "directory": "modules",
         "description": "Prebid.js - Header bidding wrapper for publishers",
         "versions": ["master"],
-        "parser_type": "default"
+        "parser_type": "prebid_js",
+        "modules_path": "modules"
     },
     "prebid-server-java": {
         "repo": "prebid/prebid-server-java",
-        "directory": "src/main/java/org/prebid/server",
         "description": "Prebid Server Java implementation",
         "versions": ["master"],
-        "parser_type": "default"
+        "parser_type": "prebid_server_java",
+        "paths": {
+            "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+            "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+            "General Modules": "extra/modules",
+            "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy"
+        }
     },
     "prebid-server": {
         "repo": "prebid/prebid-server",
-        "directory": "adapters",
         "description": "Prebid Server Go implementation",
         "versions": ["master"],
-        "parser_type": "default"
+        "parser_type": "prebid_server_go",
+        "paths": {
+            "Bid Adapters": "adapters",
+            "Analytics Adapters": "analytics",
+            "General Modules": "modules"
+        }
     },
     "prebid-docs": {
         "repo": "prebid/prebid.github.io",
-        "directory": "dev-docs",
-        "description": "Prebid documentation site",
+        "description": "Prebid Documentation site",
         "versions": ["master"],
-        "parser_type": "markdown"
+        "parser_type": "prebid_docs",
+        "paths": {
+            "Bid Adapters": "dev-docs/bidders",
+            "Analytics Adapters": "dev-docs/analytics",
+            "Identity Modules": "dev-docs/modules/userid-submodules",
+            "Real-Time Data Modules": "dev-docs/modules",
+            "Video Modules": "dev-docs/modules",
+            "Other Modules": "dev-docs/modules"
+        }
     }
 }

--- a/src/repo_modules_by_version/repos.json
+++ b/src/repo_modules_by_version/repos.json
@@ -5,7 +5,9 @@
         "description": "Prebid.js - Header bidding wrapper for publishers",
         "versions": ["master"],
         "parser_type": "prebid_js",
-        "modules_path": "modules"
+        "modules_path": "modules",
+        "fetch_strategy": "filenames_only",
+        "output_filename_slug": "prebid.js"
     },
     "prebid-server-java": {
         "repo": "prebid/prebid-server-java",
@@ -17,7 +19,9 @@
             "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
             "General Modules": "extra/modules",
             "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy"
-        }
+        },
+        "fetch_strategy": "directory_names",
+        "output_filename_slug": "prebid.server.java"
     },
     "prebid-server": {
         "repo": "prebid/prebid-server",
@@ -28,7 +32,9 @@
             "Bid Adapters": "adapters",
             "Analytics Adapters": "analytics",
             "General Modules": "modules"
-        }
+        },
+        "fetch_strategy": "directory_names",
+        "output_filename_slug": "prebid.server.go"
     },
     "prebid-docs": {
         "repo": "prebid/prebid.github.io",
@@ -42,6 +48,9 @@
             "Real-Time Data Modules": "dev-docs/modules",
             "Video Modules": "dev-docs/modules",
             "Other Modules": "dev-docs/modules"
-        }
+        },
+        "fetch_strategy": "filenames_only",
+        "version_override": "master",
+        "output_filename_slug": "prebid.github.io"
     }
 }

--- a/tests/test_repo_modules_by_version/test_config_refactoring.py
+++ b/tests/test_repo_modules_by_version/test_config_refactoring.py
@@ -1,0 +1,192 @@
+"""
+Tests for configuration refactoring - new fields and functionality.
+
+This test suite validates:
+- New RepoConfig fields (fetch_strategy, version_override, output_filename_slug)
+- Backward compatibility with existing configurations
+- Configuration validation and defaults
+"""
+
+from src.repo_modules_by_version.config import RepoConfig, get_available_repos
+
+
+class TestRepoConfigNewFields:
+    """Test new fields added to RepoConfig for configuration-driven architecture."""
+
+    def test_repo_config_with_all_new_fields(self):
+        """Test RepoConfig creation with all new fields."""
+        config = RepoConfig(
+            repo="test/repo",
+            description="Test repository",
+            versions=["v1.0.0"],
+            parser_type="test",
+            fetch_strategy="filenames_only",
+            version_override="master",
+            output_filename_slug="custom.name",
+        )
+
+        assert config.fetch_strategy == "filenames_only"
+        assert config.version_override == "master"
+        assert config.output_filename_slug == "custom.name"
+
+    def test_repo_config_with_partial_new_fields(self):
+        """Test RepoConfig with only some new fields specified."""
+        config = RepoConfig(
+            repo="test/repo",
+            description="Test repository",
+            versions=["v1.0.0"],
+            fetch_strategy="directory_names",
+            version_override="v2.0.0",
+            # output_filename_slug not specified
+        )
+
+        assert config.fetch_strategy == "directory_names"
+        assert config.version_override == "v2.0.0"
+        assert config.output_filename_slug is None
+
+    def test_repo_config_default_values(self):
+        """Test that new fields have appropriate default values."""
+        config = RepoConfig(
+            repo="test/repo", description="Test repository", versions=["v1.0.0"]
+        )
+
+        assert config.fetch_strategy == "full_content"  # Default value
+        assert config.version_override is None  # Default value
+        assert config.output_filename_slug is None  # Default value
+
+    def test_fetch_strategy_values(self):
+        """Test different fetch strategy values."""
+        strategies = ["full_content", "filenames_only", "directory_names"]
+
+        for strategy in strategies:
+            config = RepoConfig(
+                repo="test/repo",
+                description="Test repository",
+                versions=["v1.0.0"],
+                fetch_strategy=strategy,
+            )
+            assert config.fetch_strategy == strategy
+
+
+class TestRepositoryConfigurations:
+    """Test that all repository configurations include the new fields."""
+
+    def test_all_repos_have_fetch_strategy(self):
+        """Test that all configured repositories have fetch_strategy set."""
+        repos = get_available_repos()
+
+        for repo_name, config in repos.items():
+            assert hasattr(
+                config, "fetch_strategy"
+            ), f"{repo_name} missing fetch_strategy"
+            assert config.fetch_strategy in [
+                "full_content",
+                "filenames_only",
+                "directory_names",
+            ], f"{repo_name} has invalid fetch_strategy: {config.fetch_strategy}"
+
+    def test_prebid_docs_has_version_override(self):
+        """Test that prebid-docs has version_override set to master."""
+        repos = get_available_repos()
+        prebid_docs_config = repos.get("prebid-docs")
+
+        assert prebid_docs_config is not None
+        assert prebid_docs_config.version_override == "master"
+
+    def test_repos_have_output_filename_slugs(self):
+        """Test that repositories have appropriate output_filename_slug values."""
+        repos = get_available_repos()
+
+        expected_slugs = {
+            "prebid-js": "prebid.js",
+            "prebid-server": "prebid.server.go",
+            "prebid-server-java": "prebid.server.java",
+            "prebid-docs": "prebid.github.io",
+        }
+
+        for repo_name, expected_slug in expected_slugs.items():
+            config = repos.get(repo_name)
+            assert config is not None, f"Repository {repo_name} not found"
+            assert (
+                config.output_filename_slug == expected_slug
+            ), f"{repo_name} has wrong slug: {config.output_filename_slug}"
+
+    def test_fetch_strategies_are_appropriate(self):
+        """Test that repositories have appropriate fetch strategies for their use case."""
+        repos = get_available_repos()
+
+        expected_strategies = {
+            "prebid-js": "filenames_only",  # For modules parsing
+            "prebid-server": "directory_names",  # For directory structure
+            "prebid-server-java": "directory_names",  # For directory structure
+            "prebid-docs": "filenames_only",  # For documentation files
+        }
+
+        for repo_name, expected_strategy in expected_strategies.items():
+            config = repos.get(repo_name)
+            assert config is not None, f"Repository {repo_name} not found"
+            assert (
+                config.fetch_strategy == expected_strategy
+            ), f"{repo_name} has wrong strategy: {config.fetch_strategy}"
+
+
+class TestBackwardCompatibility:
+    """Test that existing functionality still works with new fields."""
+
+    def test_existing_fields_unchanged(self):
+        """Test that existing RepoConfig fields are unchanged."""
+        config = RepoConfig(
+            repo="test/repo",
+            description="Test repository",
+            versions=["v1.0.0"],
+            parser_type="test",
+            directory="test-dir",
+            modules_path="modules",
+            paths={"Category": "path"},
+        )
+
+        # Verify existing fields still work
+        assert config.repo == "test/repo"
+        assert config.description == "Test repository"
+        assert config.versions == ["v1.0.0"]
+        assert config.parser_type == "test"
+        assert config.directory == "test-dir"
+        assert config.modules_path == "modules"
+        assert config.paths == {"Category": "path"}
+
+    def test_json_loading_with_missing_new_fields(self):
+        """Test that configurations load correctly even without new fields."""
+        # This simulates loading old configuration files
+        old_config_data = {
+            "repo": "test/old-repo",
+            "description": "Old repository",
+            "versions": ["v1.0.0"],
+            "parser_type": "default",
+            # Missing new fields: fetch_strategy, version_override, output_filename_slug
+        }
+
+        config = RepoConfig(**old_config_data)
+
+        # Should have default values for new fields
+        assert config.fetch_strategy == "full_content"
+        assert config.version_override is None
+        assert config.output_filename_slug is None
+
+        # Existing fields should work
+        assert config.repo == "test/old-repo"
+        assert config.description == "Old repository"
+
+    def test_configuration_loading_doesnt_break(self):
+        """Test that the actual repository configuration loading doesn't break."""
+        # This tests the real configuration loading from repos.json
+        repos = get_available_repos()
+
+        # Should load without errors
+        assert len(repos) > 0
+
+        # All configs should be valid RepoConfig instances
+        for config in repos.values():
+            assert isinstance(config, RepoConfig)
+            assert hasattr(config, "fetch_strategy")
+            assert hasattr(config, "version_override")
+            assert hasattr(config, "output_filename_slug")

--- a/tests/test_repo_modules_by_version/test_filename_generation.py
+++ b/tests/test_repo_modules_by_version/test_filename_generation.py
@@ -1,0 +1,302 @@
+"""
+Tests for filename generation logic with new naming conventions.
+
+This test suite validates:
+- Correct filename generation for all repo types
+- Special handling for prebid.js naming
+- Special handling for prebid-server (Go) -> prebid.server.go
+- Proper version cleaning (/ -> _)
+- File replacement logic
+"""
+
+import os
+import tempfile
+from unittest.mock import Mock, patch
+
+from src.repo_modules_by_version.config import RepoConfig
+
+
+class TestFilenameGeneration:
+    """Test filename generation for all repository types."""
+
+    def test_prebid_js_filename_generation(self):
+        """Test that Prebid.js generates correct filename."""
+        config = RepoConfig(
+            repo="prebid/Prebid.js",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_js",
+            modules_path="modules",
+        )
+
+        # Simulate filename generation logic
+        owner, repo = config.repo.split("/")
+        repo_name = repo.lower().replace("-", ".")
+
+        # prebid.js should remain as prebid.js (no special handling needed)
+        version_clean = "9.51.0"
+        expected_filename = f"{repo_name}_modules_version_{version_clean}.txt"
+
+        assert expected_filename == "prebid.js_modules_version_9.51.0.txt"
+
+    def test_prebid_server_go_filename_generation(self):
+        """Test that Prebid Server Go generates correct filename with .go suffix."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={"Bid Adapters": "adapters"},
+        )
+
+        # Simulate filename generation logic
+        owner, repo = config.repo.split("/")
+        repo_name = repo.lower().replace("-", ".")
+
+        # Special handling for prebid-server (Go)
+        if repo_name == "prebid.server":
+            repo_name = "prebid.server.go"
+
+        version_clean = "v3.8.0"
+        expected_filename = f"{repo_name}_modules_version_{version_clean}.txt"
+
+        assert expected_filename == "prebid.server.go_modules_version_v3.8.0.txt"
+
+    def test_prebid_server_java_filename_generation(self):
+        """Test that Prebid Server Java generates correct filename."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={"Bid Adapters": "src/main/java/org/prebid/server/bidder"},
+        )
+
+        # Simulate filename generation logic
+        owner, repo = config.repo.split("/")
+        repo_name = repo.lower().replace("-", ".")
+
+        version_clean = "3.27.0"
+        expected_filename = f"{repo_name}_modules_version_{version_clean}.txt"
+
+        assert expected_filename == "prebid.server.java_modules_version_3.27.0.txt"
+
+    def test_prebid_docs_filename_generation(self):
+        """Test that Prebid Docs generates correct filename."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={"Bid Adapters": "dev-docs/bidders"},
+        )
+
+        # Simulate filename generation logic
+        owner, repo = config.repo.split("/")
+        repo_name = repo.lower().replace("-", ".")
+
+        version_clean = "master"
+        expected_filename = f"{repo_name}_modules_version_{version_clean}.txt"
+
+        assert expected_filename == "prebid.github.io_modules_version_master.txt"
+
+    def test_version_cleaning(self):
+        """Test that version strings are properly cleaned for filenames."""
+        test_cases = [
+            ("v1.0.0", "v1.0.0"),
+            ("feature/test", "feature_test"),
+            ("release/v2.1.0", "release_v2.1.0"),
+            ("master", "master"),
+            ("v3.8.0", "v3.8.0"),
+        ]
+
+        for input_version, expected_clean in test_cases:
+            version_clean = input_version.replace("/", "_")
+            assert version_clean == expected_clean
+
+    def test_repository_name_conversion(self):
+        """Test repository name conversion logic."""
+        test_cases = [
+            ("owner/Prebid.js", "prebid.js"),
+            ("owner/prebid-server", "prebid.server"),
+            ("owner/prebid-server-java", "prebid.server.java"),
+            ("owner/prebid.github.io", "prebid.github.io"),
+            ("owner/test-repo", "test.repo"),
+            ("owner/test_repo", "test_repo"),
+        ]
+
+        for full_repo, expected_name in test_cases:
+            owner, repo = full_repo.split("/")
+            repo_name = repo.lower().replace("-", ".")
+            assert repo_name == expected_name
+
+    def test_special_naming_rules(self):
+        """Test all special naming rules for filename generation."""
+        test_cases = [
+            # (repo_name_after_conversion, expected_final_name)
+            ("prebid.js", "prebid.js"),  # No change needed
+            ("prebid.server", "prebid.server.go"),  # Add .go suffix
+            ("prebid.server.java", "prebid.server.java"),  # No change
+            ("prebid.github.io", "prebid.github.io"),  # No change
+        ]
+
+        for input_name, expected_output in test_cases:
+            repo_name = input_name
+
+            # Apply special handling rules
+            if repo_name == "prebid.server":
+                repo_name = "prebid.server.go"
+
+            assert repo_name == expected_output
+
+
+@patch("src.repo_modules_by_version.main.GitHubClient")
+@patch("src.repo_modules_by_version.main.ParserFactory")
+class TestFilenameGenerationIntegration:
+    """Integration tests for filename generation within main function."""
+
+    def test_main_function_filename_generation(
+        self, mock_parser_factory, mock_github_client
+    ):
+        """Test filename generation through main function execution."""
+        # Mock the necessary components
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "prebid/prebid-server",
+            "version": "v3.8.0",
+            "paths": {"adapters": {"adapters/test": ""}},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Mock config
+        with patch(
+            "src.repo_modules_by_version.main.get_repo_config_with_versions"
+        ) as mock_get_config:
+            mock_config = RepoConfig(
+                repo="prebid/prebid-server",
+                description="Test",
+                versions=["master"],
+                parser_type="prebid_server_go",
+                paths={"Bid Adapters": "adapters"},
+            )
+            mock_get_config.return_value = mock_config
+
+            # Test with temporary directory
+            with tempfile.TemporaryDirectory() as temp_dir:
+                original_cwd = os.getcwd()
+                try:
+                    os.chdir(temp_dir)
+
+                    # Import and test main function
+                    from src.repo_modules_by_version.main import main
+
+                    # Mock sys.argv
+                    with patch(
+                        "sys.argv",
+                        ["main.py", "--repo", "prebid-server", "--version", "v3.8.0"],
+                    ):
+                        main()
+
+                    # Check that the correct filename was generated
+                    expected_filename = "prebid.server.go_modules_version_v3.8.0.txt"
+                    assert os.path.exists(
+                        expected_filename
+                    ), f"Expected file {expected_filename} was not created"
+
+                finally:
+                    os.chdir(original_cwd)
+
+
+class TestFileReplacementLogic:
+    """Test file replacement functionality."""
+
+    def test_file_replacement_detection(self):
+        """Test that existing files are properly detected and replaced."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_filename = os.path.join(temp_dir, "test_file.txt")
+
+            # Create initial file
+            with open(test_filename, "w") as f:
+                f.write("original content")
+
+            # Verify file exists
+            assert os.path.exists(test_filename)
+
+            # Test replacement
+            with open(test_filename, "w") as f:
+                f.write("new content")
+
+            # Verify content was replaced
+            with open(test_filename) as f:
+                content = f.read()
+
+            assert content == "new content"
+
+    def test_master_file_replacement_message(self):
+        """Test that master files show proper replacement message."""
+        # This would be tested in integration with main function
+        # but testing the logic here
+        test_filenames = [
+            "prebid.js_modules_version_master.txt",
+            "prebid.server.go_modules_version_master.txt",
+            "prebid.github.io_modules_version_master.txt",
+            "prebid.js_modules_version_v9.51.0.txt",  # Not master
+        ]
+
+        for filename in test_filenames:
+            if filename.endswith("_master.txt"):
+                # Should show replacement message for master files
+                assert "master" in filename
+            else:
+                # Regular version files
+                assert "master" not in filename or not filename.endswith("_master.txt")
+
+
+class TestFilenamingEdgeCases:
+    """Test edge cases in filename generation."""
+
+    def test_empty_version_handling(self):
+        """Test handling of empty or None versions."""
+        # Version should always be provided, but test graceful handling
+        version = ""
+        version_clean = version.replace("/", "_") if version else "unknown"
+        assert version_clean == "unknown"
+
+    def test_special_characters_in_version(self):
+        """Test handling of special characters in version strings."""
+        test_cases = [
+            ("v1.0.0-beta", "v1.0.0-beta"),
+            ("release/v2.1.0-rc1", "release_v2.1.0-rc1"),
+            ("feature/fix-bug", "feature_fix-bug"),
+            ("hotfix/urgent-fix", "hotfix_urgent-fix"),
+        ]
+
+        for input_version, expected_clean in test_cases:
+            version_clean = input_version.replace("/", "_")
+            assert version_clean == expected_clean
+
+    def test_long_version_strings(self):
+        """Test handling of very long version strings."""
+        long_version = "very-long-feature-branch-name-that-exceeds-normal-length/v1.0.0"
+        version_clean = long_version.replace("/", "_")
+        expected = "very-long-feature-branch-name-that-exceeds-normal-length_v1.0.0"
+        assert version_clean == expected
+
+    def test_repo_name_with_numbers(self):
+        """Test repository names containing numbers."""
+        test_cases = [
+            ("owner/project-v2", "project.v2"),
+            ("owner/service-1.0", "service.1.0"),
+            ("owner/tool-123-beta", "tool.123.beta"),
+        ]
+
+        for full_repo, expected_name in test_cases:
+            owner, repo = full_repo.split("/")
+            repo_name = repo.lower().replace("-", ".")
+            assert repo_name == expected_name

--- a/tests/test_repo_modules_by_version/test_filename_generation.py
+++ b/tests/test_repo_modules_by_version/test_filename_generation.py
@@ -175,17 +175,25 @@ class TestFilenameGenerationIntegration:
         mock_factory.get_parser.return_value = mock_parser
 
         # Mock config
-        with patch(
-            "src.repo_modules_by_version.main.get_repo_config_with_versions"
-        ) as mock_get_config:
+        with (
+            patch(
+                "src.repo_modules_by_version.main.get_repo_config_with_versions"
+            ) as mock_get_config,
+            patch(
+                "src.repo_modules_by_version.main.get_available_repos"
+            ) as mock_get_repos,
+        ):
             mock_config = RepoConfig(
                 repo="prebid/prebid-server",
                 description="Test",
                 versions=["master"],
                 parser_type="prebid_server_go",
                 paths={"Bid Adapters": "adapters"},
+                fetch_strategy="directory_names",
+                output_filename_slug="prebid.server.go",
             )
             mock_get_config.return_value = mock_config
+            mock_get_repos.return_value = {"prebid-server": mock_config}
 
             # Test with temporary directory
             with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_repo_modules_by_version/test_github_client_refactored.py
+++ b/tests/test_repo_modules_by_version/test_github_client_refactored.py
@@ -1,0 +1,357 @@
+"""
+Tests for refactored GitHubClient with configuration-driven fetch strategies.
+
+This test suite validates:
+- Configuration-driven fetch strategy system
+- Removal of hardcoded repository logic
+- All fetch strategy types work correctly
+- Error handling and edge cases
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from github import GithubException
+
+from src.repo_modules_by_version.github_client import GitHubClient
+
+
+class TestFetchStrategies:
+    """Test the configuration-driven fetch strategy system."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        with patch("src.repo_modules_by_version.github_client.Github"):
+            self.client = GitHubClient()
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_full_content(self, mock_github_class):
+        """Test fetch_strategy='full_content' uses _fetch_directory_contents."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Mock the internal methods
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client,
+                "_fetch_directory_contents",
+                return_value={"file1.txt": "content"},
+            ) as mock_fetch,
+        ):
+            result = client.fetch_repository_data(
+                "test/repo", "v1.0.0", directory="src", fetch_strategy="full_content"
+            )
+
+            # Verify _fetch_directory_contents was called
+            mock_fetch.assert_called_once_with(mock_repo, "src", "abc123")
+            assert "files" in result
+            assert result["files"] == {"file1.txt": "content"}
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_filenames_only(self, mock_github_class):
+        """Test fetch_strategy='filenames_only' uses _fetch_directory_filenames."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Mock the internal methods
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client, "_fetch_directory_filenames", return_value={"file1.js": ""}
+            ) as mock_fetch,
+        ):
+            result = client.fetch_repository_data(
+                "test/repo",
+                "v1.0.0",
+                modules_path="modules",
+                fetch_strategy="filenames_only",
+            )
+
+            # Verify _fetch_directory_filenames was called with .js extension
+            mock_fetch.assert_called_once_with(mock_repo, "modules", "abc123", [".js"])
+            assert result["files"] == {"file1.js": ""}
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_directory_names(self, mock_github_class):
+        """Test fetch_strategy='directory_names' uses _fetch_directory_names."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Mock the internal methods
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client, "_fetch_directory_names", return_value={"dir1": "", "dir2": ""}
+            ) as mock_fetch,
+        ):
+            result = client.fetch_repository_data(
+                "test/repo",
+                "v1.0.0",
+                directory="adapters",
+                fetch_strategy="directory_names",
+            )
+
+            # Verify _fetch_directory_names was called
+            mock_fetch.assert_called_once_with(mock_repo, "adapters", "abc123")
+            assert result["files"] == {"dir1": "", "dir2": ""}
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_multi_path_filenames_only(self, mock_github_class):
+        """Test multi-path fetching with filenames_only strategy."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Mock the internal methods
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client, "_fetch_file_names", return_value={"file1.md": ""}
+            ) as mock_fetch,
+        ):
+            result = client.fetch_repository_data(
+                "test/repo",
+                "v1.0.0",
+                paths={"Category": "docs"},
+                fetch_strategy="filenames_only",
+            )
+
+            # Verify _fetch_file_names was called for multi-path
+            mock_fetch.assert_called_once_with(mock_repo, "docs", "abc123")
+            assert "paths" in result
+            assert result["paths"]["docs"] == {"file1.md": ""}
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_multi_path_directory_names(self, mock_github_class):
+        """Test multi-path fetching with directory_names strategy."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Mock the internal methods
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client,
+                "_fetch_directory_names",
+                return_value={"subdir1": "", "subdir2": ""},
+            ) as mock_fetch,
+        ):
+            result = client.fetch_repository_data(
+                "test/repo",
+                "v1.0.0",
+                paths={"Adapters": "adapters", "Modules": "modules"},
+                fetch_strategy="directory_names",
+            )
+
+            # Verify _fetch_directory_names was called for each path
+            assert mock_fetch.call_count == 2
+            assert "paths" in result
+            assert len(result["paths"]) == 2
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_invalid_fetch_strategy_raises_error(self, mock_github_class):
+        """Test that invalid fetch strategy raises ValueError."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        with patch.object(client, "_get_reference", return_value="abc123"):
+            with pytest.raises(
+                Exception, match="Unsupported fetch strategy: invalid_strategy"
+            ):
+                client.fetch_repository_data(
+                    "test/repo",
+                    "v1.0.0",
+                    directory="src",
+                    fetch_strategy="invalid_strategy",
+                )
+
+
+class TestHardcodedLogicRemoval:
+    """Test that hardcoded repository-specific logic has been removed."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        with patch("src.repo_modules_by_version.github_client.Github"):
+            self.client = GitHubClient()
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_no_hardcoded_prebid_github_io_logic(self, mock_github_class):
+        """Test that prebid.github.io is not treated specially in GitHubClient."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Mock internal methods to track calls
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(client, "_fetch_file_names") as mock_file_names,
+            patch.object(client, "_fetch_directory_names") as mock_dir_names,
+        ):
+            # Test that prebid.github.io uses fetch_strategy, not hardcoded logic
+            client.fetch_repository_data(
+                "prebid/prebid.github.io",  # This was hardcoded before
+                "v1.0.0",
+                paths={"Docs": "dev-docs"},
+                fetch_strategy="directory_names",  # Should use directory_names, not filenames
+            )
+
+            # Should call _fetch_directory_names because of fetch_strategy, not _fetch_file_names
+            mock_dir_names.assert_called_once()
+            mock_file_names.assert_not_called()
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_any_repo_can_use_any_strategy(self, mock_github_class):
+        """Test that any repository can use any fetch strategy."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        test_repos = ["owner/repo1", "different/repo2", "third/repo3"]
+        test_strategies = ["full_content", "filenames_only", "directory_names"]
+
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(client, "_fetch_directory_contents", return_value={}),
+            patch.object(client, "_fetch_directory_filenames", return_value={}),
+            patch.object(client, "_fetch_directory_names", return_value={}),
+        ):
+            # Test that all combinations work
+            for repo in test_repos:
+                for strategy in test_strategies:
+                    result = client.fetch_repository_data(
+                        repo, "v1.0.0", directory="test", fetch_strategy=strategy
+                    )
+
+                    # Should succeed without repository-specific errors
+                    assert "repo" in result
+                    assert result["repo"] == repo
+
+
+class TestFetchStrategyEdgeCases:
+    """Test edge cases and error conditions for fetch strategies."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        with patch("src.repo_modules_by_version.github_client.Github"):
+            self.client = GitHubClient()
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_with_no_directory(self, mock_github_class):
+        """Test fetch strategy with no directory specified raises appropriate error."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        with patch.object(client, "_get_reference", return_value="abc123"):
+            with pytest.raises(Exception, match="No directory specified"):
+                client.fetch_repository_data(
+                    "test/repo",
+                    "v1.0.0",
+                    # No directory, modules_path, or paths specified
+                    fetch_strategy="full_content",
+                )
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_fetch_strategy_with_github_exception(self, mock_github_class):
+        """Test fetch strategy error handling with GitHub exceptions."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        # Create a custom exception class for testing
+        class TestGithubException(GithubException):
+            def __init__(self):
+                super().__init__(404, "Not found")
+                self._data = {"message": "Repository not found"}
+
+            @property
+            def data(self):
+                return self._data
+
+        # Mock _fetch_directory_contents to raise GitHub exception
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client, "_fetch_directory_contents", side_effect=TestGithubException()
+            ),
+        ):
+            with pytest.raises(Exception, match="GitHub API error"):
+                client.fetch_repository_data(
+                    "test/repo",
+                    "v1.0.0",
+                    directory="nonexistent",
+                    fetch_strategy="full_content",
+                )
+
+    @patch("src.repo_modules_by_version.github_client.Github")
+    def test_default_fetch_strategy(self, mock_github_class):
+        """Test that default fetch_strategy is 'full_content'."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_class.return_value = mock_github
+        mock_repo = Mock()
+        mock_github.get_repo.return_value = mock_repo
+
+        client = GitHubClient()
+
+        with (
+            patch.object(client, "_get_reference", return_value="abc123"),
+            patch.object(
+                client, "_fetch_directory_contents", return_value={}
+            ) as mock_fetch,
+        ):
+            # Don't specify fetch_strategy - should default to full_content
+            client.fetch_repository_data(
+                "test/repo",
+                "v1.0.0",
+                directory="src",
+                # fetch_strategy not specified
+            )
+
+            # Should call _fetch_directory_contents (full_content strategy)
+            mock_fetch.assert_called_once()

--- a/tests/test_repo_modules_by_version/test_integration_new_repos.py
+++ b/tests/test_repo_modules_by_version/test_integration_new_repos.py
@@ -1,0 +1,484 @@
+"""
+Integration tests for new repository configurations and parsers added on addFilesToParse branch.
+
+This test suite validates:
+- All new repo configurations (prebid-server, prebid-server-java, prebid-docs)
+- New parser implementations (PrebidServerGoParser, PrebidServerJavaParser, PrebidDocsParser)
+- Updated naming conventions and filename generation
+- Multi-path parsing functionality
+- Underscore to space conversion
+- Master override for prebid.github.io
+"""
+
+from src.repo_modules_by_version.config import RepoConfig, get_available_repos
+from src.repo_modules_by_version.parser_factory import (
+    ParserFactory,
+    PrebidDocsParser,
+    PrebidJSParser,
+    PrebidServerGoParser,
+    PrebidServerJavaParser,
+)
+
+
+class TestNewRepoConfigurations:
+    """Test all new repository configurations."""
+
+    def test_all_prebid_repos_exist(self):
+        """Test that all expected Prebid repositories are configured."""
+        repos = get_available_repos()
+
+        expected_repos = {
+            "prebid-js",
+            "prebid-server",
+            "prebid-server-java",
+            "prebid-docs",
+        }
+
+        assert expected_repos.issubset(
+            set(repos.keys())
+        ), f"Missing repos: {expected_repos - set(repos.keys())}"
+
+    def test_prebid_js_config(self):
+        """Test Prebid.js repository configuration."""
+        repos = get_available_repos()
+        config = repos["prebid-js"]
+
+        assert config.repo == "prebid/Prebid.js"
+        assert config.parser_type == "prebid_js"
+        assert config.modules_path == "modules"
+        assert "master" in config.versions
+
+    def test_prebid_server_go_config(self):
+        """Test Prebid Server Go repository configuration."""
+        repos = get_available_repos()
+        config = repos["prebid-server"]
+
+        assert config.repo == "prebid/prebid-server"
+        assert config.parser_type == "prebid_server_go"
+        assert config.paths is not None
+        assert "Bid Adapters" in config.paths
+        assert "Analytics Adapters" in config.paths
+        assert "General Modules" in config.paths
+        assert config.paths["Bid Adapters"] == "adapters"
+
+    def test_prebid_server_java_config(self):
+        """Test Prebid Server Java repository configuration."""
+        repos = get_available_repos()
+        config = repos["prebid-server-java"]
+
+        assert config.repo == "prebid/prebid-server-java"
+        assert config.parser_type == "prebid_server_java"
+        assert config.paths is not None
+        assert "Privacy Modules" in config.paths
+        assert "General Modules" in config.paths
+
+    def test_prebid_docs_config(self):
+        """Test Prebid Documentation repository configuration."""
+        repos = get_available_repos()
+        config = repos["prebid-docs"]
+
+        assert config.repo == "prebid/prebid.github.io"
+        assert config.parser_type == "prebid_docs"
+        assert config.paths is not None
+        assert "Identity Modules" in config.paths
+        assert "Real-Time Data Modules" in config.paths
+        assert "Video Modules" in config.paths
+
+
+class TestParserFactory:
+    """Test parser factory with new parser types."""
+
+    def test_parser_factory_creates_correct_parsers(self):
+        """Test that parser factory creates the correct parser instances."""
+        factory = ParserFactory()
+
+        # Test all new parser types
+        test_cases = [
+            ("prebid_js", PrebidJSParser),
+            ("prebid_server_go", PrebidServerGoParser),
+            ("prebid_server_java", PrebidServerJavaParser),
+            ("prebid_docs", PrebidDocsParser),
+        ]
+
+        for parser_type, expected_class in test_cases:
+            config = RepoConfig(
+                repo="test/repo",
+                description="Test",
+                versions=["master"],
+                parser_type=parser_type,
+            )
+
+            parser = factory.get_parser(config)
+            assert isinstance(
+                parser, expected_class
+            ), f"Expected {expected_class.__name__} for {parser_type}, got {type(parser).__name__}"
+
+    def test_parser_factory_available_parsers(self):
+        """Test that all new parser types are available."""
+        factory = ParserFactory()
+        available = factory.get_available_parsers()
+
+        expected_parsers = {
+            "prebid_js",
+            "prebid_server_go",
+            "prebid_server_java",
+            "prebid_docs",
+        }
+
+        assert expected_parsers.issubset(
+            set(available)
+        ), f"Missing parsers: {expected_parsers - set(available)}"
+
+
+class TestUnderscoreToSpaceConversion:
+    """Test underscore to space conversion in parser outputs."""
+
+    def test_prebid_server_go_underscore_conversion(self):
+        """Test that PrebidServerGoParser converts underscores to spaces."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={"Bid Adapters": "adapters"},
+        )
+        parser = PrebidServerGoParser(config)
+
+        # Mock data with underscores
+        test_data = {
+            "repo": "prebid/prebid-server",
+            "version": "master",
+            "paths": {
+                "adapters": {
+                    "adapters/test_adapter": "",
+                    "adapters/another_test": "",
+                    "adapters/normal": "",
+                }
+            },
+        }
+
+        result = parser.parse(test_data)
+
+        # Check that underscores are converted to spaces
+        assert "test adapter" in result
+        assert "another test" in result
+        assert "normal" in result
+        assert "test_adapter" not in result
+        assert "another_test" not in result
+
+    def test_prebid_server_java_underscore_conversion(self):
+        """Test that PrebidServerJavaParser handles naming correctly."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={"General Modules": "extra/modules"},
+        )
+        parser = PrebidServerJavaParser(config)
+
+        # Mock data with dashes and pb- prefix
+        test_data = {
+            "repo": "prebid/prebid-server-java",
+            "version": "master",
+            "paths": {
+                "extra/modules": {
+                    "extra/modules/pb-test-module": "",
+                    "extra/modules/another-module": "",
+                }
+            },
+        }
+
+        result = parser.parse(test_data)
+
+        # Check that dashes are converted to spaces and pb- prefix is removed
+        assert "test module" in result
+        assert "another module" in result
+        assert "pb-test-module" not in result
+
+
+class TestMultiPathParsing:
+    """Test multi-path parsing functionality."""
+
+    def test_prebid_server_go_multi_path_parsing(self):
+        """Test that PrebidServerGoParser handles multiple paths correctly."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={
+                "Bid Adapters": "adapters",
+                "Analytics Adapters": "analytics",
+                "General Modules": "modules",
+            },
+        )
+        parser = PrebidServerGoParser(config)
+
+        test_data = {
+            "repo": "prebid/prebid-server",
+            "version": "master",
+            "paths": {
+                "adapters": {
+                    "adapters/appnexus": "",
+                    "adapters/rubicon": "",
+                },
+                "analytics": {
+                    "analytics/pubstack": "",
+                    "analytics/build": "",  # Should be excluded
+                },
+                "modules": {
+                    "modules/fiftyonedegrees": "",
+                    "modules/fiftyonedegrees/devicedetection": "",
+                },
+            },
+        }
+
+        result = parser.parse(test_data)
+
+        # Check all categories appear
+        assert "📦 Bid Adapters" in result
+        assert "📦 Analytics Adapters" in result
+        assert "📦 General Modules" in result
+
+        # Check correct items appear
+        assert "appnexus" in result
+        assert "rubicon" in result
+        assert "pubstack" in result
+        assert "fiftyonedegrees devicedetection" in result
+
+        # Check excluded items don't appear
+        assert "build" not in result
+
+    def test_prebid_docs_multi_path_parsing(self):
+        """Test that PrebidDocsParser handles file-based parsing correctly."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Real-Time Data Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        test_data = {
+            "repo": "prebid/prebid.github.io",
+            "version": "master",
+            "paths": {
+                "dev-docs/bidders": {
+                    "dev-docs/bidders/appnexus.md": "",
+                    "dev-docs/bidders/rubicon.md": "",
+                },
+                "dev-docs/modules": {
+                    "dev-docs/modules/confiantRtdProvider.md": "",
+                    "dev-docs/modules/currency.md": "",
+                },
+            },
+        }
+
+        result = parser.parse(test_data)
+
+        # Check categories appear
+        assert "📦 Bid Adapters" in result
+        assert "📦 Real-Time Data Modules" in result
+
+        # Check suffix removal works
+        assert "confiant" in result  # RtdProvider removed
+        assert "confiantRtdProvider" not in result
+
+        # Note: currency.md doesn't have a special suffix, so it won't appear in RTD modules
+        # The parser only categorizes files with specific suffixes in the RTD category
+
+
+class TestDisplayNamingConsistency:
+    """Test that display names follow consistent naming conventions."""
+
+    def test_prebid_js_display_name(self):
+        """Test PrebidJSParser display name."""
+        config = RepoConfig(
+            repo="prebid/Prebid.js",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_js",
+            modules_path="modules",
+        )
+        parser = PrebidJSParser(config)
+
+        test_data = {
+            "repo": "prebid/Prebid.js",
+            "version": "master",
+            "directory": "modules",
+            "files": {"modules/testBidAdapter.js": ""},
+            "metadata": {"total_files": 1},
+        }
+
+        result = parser.parse(test_data)
+        assert "Prebid.js Module Categories:" in result
+
+    def test_prebid_server_go_display_name(self):
+        """Test PrebidServerGoParser display name."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={"Bid Adapters": "adapters"},
+        )
+        parser = PrebidServerGoParser(config)
+
+        test_data = {
+            "repo": "prebid/prebid-server",
+            "version": "master",
+            "paths": {"adapters": {"adapters/test": ""}},
+        }
+
+        result = parser.parse(test_data)
+        assert "Prebid Server Go Categories:" in result
+
+    def test_prebid_server_java_display_name(self):
+        """Test PrebidServerJavaParser display name."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={"Bid Adapters": "src/main/java/org/prebid/server/bidder"},
+        )
+        parser = PrebidServerJavaParser(config)
+
+        test_data = {
+            "repo": "prebid/prebid-server-java",
+            "version": "master",
+            "paths": {
+                "src/main/java/org/prebid/server/bidder": {
+                    "src/main/java/org/prebid/server/bidder/test": ""
+                }
+            },
+        }
+
+        result = parser.parse(test_data)
+        assert "Prebid Server Java Categories:" in result
+
+    def test_prebid_docs_display_name(self):
+        """Test PrebidDocsParser display name."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={"Bid Adapters": "dev-docs/bidders"},
+        )
+        parser = PrebidDocsParser(config)
+
+        test_data = {
+            "repo": "prebid/prebid.github.io",
+            "version": "master",
+            "paths": {"dev-docs/bidders": {"dev-docs/bidders/test.md": ""}},
+        }
+
+        result = parser.parse(test_data)
+        assert "Prebid Documentation Categories:" in result
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_empty_data_handling(self):
+        """Test parsers handle empty data gracefully."""
+        parsers = [
+            ("prebid_js", PrebidJSParser),
+            ("prebid_server_go", PrebidServerGoParser),
+            ("prebid_server_java", PrebidServerJavaParser),
+            ("prebid_docs", PrebidDocsParser),
+        ]
+
+        for parser_type, parser_class in parsers:
+            config = RepoConfig(
+                repo="test/repo",
+                description="Test",
+                versions=["master"],
+                parser_type=parser_type,
+                paths={"Test": "test"} if parser_type != "prebid_js" else None,
+                modules_path="modules" if parser_type == "prebid_js" else None,
+            )
+            parser = parser_class(config)
+
+            # Test with empty data
+            if parser_type == "prebid_js":
+                empty_data = {
+                    "repo": "test/repo",
+                    "version": "master",
+                    "directory": "modules",
+                    "files": {},
+                    "metadata": {"total_files": 0},
+                }
+            else:
+                empty_data = {"repo": "test/repo", "version": "master", "paths": {}}
+
+            # Should not crash
+            result = parser.parse(empty_data)
+            assert isinstance(result, str)
+            assert "test/repo" in result
+
+    def test_malformed_file_paths(self):
+        """Test parsers handle malformed file paths gracefully."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={"Bid Adapters": "adapters"},
+        )
+        parser = PrebidServerGoParser(config)
+
+        # Test with malformed paths
+        test_data = {
+            "repo": "prebid/prebid-server",
+            "version": "master",
+            "paths": {
+                "adapters": {
+                    "adapters/": "",  # Empty adapter name
+                    "adapters": "",  # No subdirectory
+                    "adapters/valid": "",  # Valid
+                }
+            },
+        }
+
+        result = parser.parse(test_data)
+
+        # Should handle gracefully and include valid entries
+        assert "valid" in result
+        # Should not crash on malformed entries
+
+    def test_general_modules_filtering(self):
+        """Test that General Modules filtering works correctly for PrebidServerGoParser."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Test",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={"General Modules": "modules"},
+        )
+        parser = PrebidServerGoParser(config)
+
+        test_data = {
+            "repo": "prebid/prebid-server",
+            "version": "master",
+            "paths": {
+                "modules": {
+                    "modules/single": "",  # Should be excluded (no subdirectory)
+                    "modules/valid/subdir": "",  # Should be included
+                    "modules/another/sub/deep": "",  # Should be included
+                }
+            },
+        }
+
+        result = parser.parse(test_data)
+
+        # Should only include modules with subdirectories
+        assert "valid subdir" in result
+        assert "another sub" in result
+        assert "single" not in result

--- a/tests/test_repo_modules_by_version/test_main.py
+++ b/tests/test_repo_modules_by_version/test_main.py
@@ -277,7 +277,7 @@ class TestMainFunction:
             main()
 
             mock_client_instance.fetch_repository_data.assert_called_once_with(
-                "test/repo", "v1.0.0", "docs"
+                "test/repo", "v1.0.0", "docs", None, None, "full_content"
             )
 
     @patch("src.repo_modules_by_version.main.GitHubClient")
@@ -309,7 +309,7 @@ class TestMainFunction:
             main()
 
             mock_client_instance.fetch_repository_data.assert_called_once_with(
-                "custom/repo", "v1.0.0", ""
+                "custom/repo", "v1.0.0", "", None, None, "full_content"
             )
 
     @patch("src.repo_modules_by_version.main.show_repo_menu")

--- a/tests/test_repo_modules_by_version/test_main_refactored.py
+++ b/tests/test_repo_modules_by_version/test_main_refactored.py
@@ -1,0 +1,443 @@
+"""
+Tests for refactored main.py with configuration-driven functionality.
+
+This test suite validates:
+- Version override functionality through configuration
+- generate_output_filename helper function
+- Configuration-driven behavior in main function
+- Integration with new RepoConfig fields
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from src.repo_modules_by_version.config import RepoConfig
+from src.repo_modules_by_version.main import generate_output_filename
+
+
+class TestGenerateOutputFilename:
+    """Test the generate_output_filename helper function."""
+
+    def test_generate_filename_with_custom_slug(self):
+        """Test filename generation with custom output_filename_slug."""
+        config = RepoConfig(
+            repo="test/repository",
+            description="Test",
+            versions=["v1.0.0"],
+            output_filename_slug="custom.name",
+        )
+
+        result = generate_output_filename(config, "v1.2.3")
+        assert result == "custom.name_modules_version_v1.2.3.txt"
+
+    def test_generate_filename_without_custom_slug(self):
+        """Test filename generation without custom slug (fallback to repo name)."""
+        config = RepoConfig(
+            repo="owner/test-repository",
+            description="Test",
+            versions=["v1.0.0"],
+            # No output_filename_slug specified
+        )
+
+        result = generate_output_filename(config, "v1.2.3")
+        # Should convert dashes to dots and use lowercase
+        assert result == "test.repository_modules_version_v1.2.3.txt"
+
+    def test_generate_filename_version_cleaning(self):
+        """Test that version strings are properly cleaned."""
+        config = RepoConfig(
+            repo="test/repo",
+            description="Test",
+            versions=["v1.0.0"],
+            output_filename_slug="test.repo",
+        )
+
+        # Test various version formats
+        test_cases = [
+            ("v1.0.0", "test.repo_modules_version_v1.0.0.txt"),
+            ("feature/branch", "test.repo_modules_version_feature_branch.txt"),
+            ("release/v2.1.0", "test.repo_modules_version_release_v2.1.0.txt"),
+            ("master", "test.repo_modules_version_master.txt"),
+        ]
+
+        for version, expected in test_cases:
+            result = generate_output_filename(config, version)
+            assert result == expected
+
+    def test_generate_filename_real_repositories(self):
+        """Test filename generation for real repository configurations."""
+        test_cases = [
+            # (repo, slug, version, expected)
+            (
+                "prebid/Prebid.js",
+                "prebid.js",
+                "v9.51.0",
+                "prebid.js_modules_version_v9.51.0.txt",
+            ),
+            (
+                "prebid/prebid-server",
+                "prebid.server.go",
+                "v3.8.0",
+                "prebid.server.go_modules_version_v3.8.0.txt",
+            ),
+            (
+                "prebid/prebid-server-java",
+                "prebid.server.java",
+                "v3.27.0",
+                "prebid.server.java_modules_version_v3.27.0.txt",
+            ),
+            (
+                "prebid/prebid.github.io",
+                "prebid.github.io",
+                "master",
+                "prebid.github.io_modules_version_master.txt",
+            ),
+        ]
+
+        for repo, slug, version, expected in test_cases:
+            config = RepoConfig(
+                repo=repo,
+                description="Test",
+                versions=["master"],
+                output_filename_slug=slug,
+            )
+
+            result = generate_output_filename(config, version)
+            assert result == expected
+
+    def test_generate_filename_fallback_logic(self):
+        """Test filename generation fallback when no slug is provided."""
+        test_cases = [
+            # (repo, version, expected)
+            ("owner/simple-repo", "v1.0.0", "simple.repo_modules_version_v1.0.0.txt"),
+            (
+                "company/complex-name-here",
+                "v2.1.0",
+                "complex.name.here_modules_version_v2.1.0.txt",
+            ),
+            ("user/CamelCase", "v1.0.0", "camelcase_modules_version_v1.0.0.txt"),
+        ]
+
+        for repo, version, expected in test_cases:
+            config = RepoConfig(
+                repo=repo,
+                description="Test",
+                versions=["master"],
+                # No output_filename_slug provided
+            )
+
+            result = generate_output_filename(config, version)
+            assert result == expected
+
+
+class TestVersionOverrideFunctionality:
+    """Test version override functionality through configuration."""
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_version_override_applied(self, mock_parser_factory, mock_github_client):
+        """Test that version_override from config is applied."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "test/repo",
+            "version": "master",  # Should be overridden version
+            "files": {},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Create config with version override
+        config = RepoConfig(
+            repo="test/repo",
+            description="Test",
+            versions=["v1.0.0", "v2.0.0"],
+            parser_type="test",
+            modules_path="modules",
+            fetch_strategy="filenames_only",
+            version_override="master",  # This should override user input
+        )
+
+        with (
+            patch(
+                "src.repo_modules_by_version.main.get_repo_config_with_versions",
+                return_value=config,
+            ),
+            patch(
+                "src.repo_modules_by_version.main.get_available_repos",
+                return_value={"test-repo": config},
+            ),
+            patch(
+                "sys.argv", ["main.py", "--repo", "test-repo", "--version", "v1.0.0"]
+            ),
+            patch("builtins.open", create=True) as mock_open,
+        ):
+            mock_open.return_value.__enter__.return_value.write = Mock()
+
+            from src.repo_modules_by_version.main import main
+
+            main()
+
+            # Verify that GitHub client was called with overridden version "master", not "v1.0.0"
+            mock_github.fetch_repository_data.assert_called_once()
+            call_args = mock_github.fetch_repository_data.call_args
+            called_version = call_args[0][1]  # Second argument is version
+            assert called_version == "master", f"Expected master, got {called_version}"
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_no_version_override_preserves_user_input(
+        self, mock_parser_factory, mock_github_client
+    ):
+        """Test that without version_override, user input is preserved."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "test/repo",
+            "version": "v1.0.0",  # Should be user input
+            "files": {},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Create config without version override
+        config = RepoConfig(
+            repo="test/repo",
+            description="Test",
+            versions=["v1.0.0", "v2.0.0"],
+            parser_type="test",
+            modules_path="modules",
+            fetch_strategy="filenames_only",
+            # No version_override specified
+        )
+
+        with (
+            patch(
+                "src.repo_modules_by_version.main.get_repo_config_with_versions",
+                return_value=config,
+            ),
+            patch(
+                "src.repo_modules_by_version.main.get_available_repos",
+                return_value={"test-repo": config},
+            ),
+            patch(
+                "sys.argv", ["main.py", "--repo", "test-repo", "--version", "v1.0.0"]
+            ),
+            patch("builtins.open", create=True) as mock_open,
+        ):
+            mock_open.return_value.__enter__.return_value.write = Mock()
+
+            from src.repo_modules_by_version.main import main
+
+            main()
+
+            # Verify that GitHub client was called with user input version "v1.0.0"
+            mock_github.fetch_repository_data.assert_called_once()
+            call_args = mock_github.fetch_repository_data.call_args
+            called_version = call_args[0][1]  # Second argument is version
+            assert called_version == "v1.0.0", f"Expected v1.0.0, got {called_version}"
+
+
+class TestConfigurationDrivenBehavior:
+    """Test that main function behavior is driven by configuration."""
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_fetch_strategy_passed_to_github_client(
+        self, mock_parser_factory, mock_github_client
+    ):
+        """Test that fetch_strategy from config is passed to GitHubClient."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "test/repo",
+            "version": "v1.0.0",
+            "files": {},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Test different fetch strategies
+        test_strategies = ["full_content", "filenames_only", "directory_names"]
+
+        for strategy in test_strategies:
+            mock_github.fetch_repository_data.reset_mock()
+
+            config = RepoConfig(
+                repo="test/repo",
+                description="Test",
+                versions=["v1.0.0"],
+                parser_type="test",
+                modules_path="modules",
+                fetch_strategy=strategy,
+            )
+
+            with (
+                patch(
+                    "src.repo_modules_by_version.main.get_repo_config_with_versions",
+                    return_value=config,
+                ),
+                patch(
+                    "src.repo_modules_by_version.main.get_available_repos",
+                    return_value={"test-repo": config},
+                ),
+                patch(
+                    "sys.argv",
+                    ["main.py", "--repo", "test-repo", "--version", "v1.0.0"],
+                ),
+                patch("builtins.open", create=True) as mock_open,
+            ):
+                mock_open.return_value.__enter__.return_value.write = Mock()
+
+                from src.repo_modules_by_version.main import main
+
+                main()
+
+                # Verify that fetch_strategy was passed to GitHubClient
+                mock_github.fetch_repository_data.assert_called_once()
+                call_args = mock_github.fetch_repository_data.call_args
+                called_strategy = call_args[0][5]  # Sixth argument is fetch_strategy
+                assert (
+                    called_strategy == strategy
+                ), f"Expected {strategy}, got {called_strategy}"
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_output_filename_uses_generate_helper(
+        self, mock_parser_factory, mock_github_client
+    ):
+        """Test that output filename uses the generate_output_filename helper."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "test/repo",
+            "version": "v1.0.0",
+            "files": {},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        config = RepoConfig(
+            repo="test/custom-repo",
+            description="Test",
+            versions=["v1.0.0"],
+            parser_type="test",
+            modules_path="modules",
+            fetch_strategy="filenames_only",
+            output_filename_slug="custom.output.name",
+        )
+
+        with (
+            patch(
+                "src.repo_modules_by_version.main.get_repo_config_with_versions",
+                return_value=config,
+            ),
+            patch(
+                "src.repo_modules_by_version.main.get_available_repos",
+                return_value={"test-repo": config},
+            ),
+            patch(
+                "sys.argv", ["main.py", "--repo", "test-repo", "--version", "v2.1.0"]
+            ),
+            patch("builtins.open", create=True) as mock_open,
+            patch("os.path.exists", return_value=False),
+        ):
+            mock_file = Mock()
+            mock_open.return_value.__enter__.return_value = mock_file
+
+            from src.repo_modules_by_version.main import main
+
+            main()
+
+            # Verify that the file was opened with the expected filename
+            expected_filename = "custom.output.name_modules_version_v2.1.0.txt"
+            mock_open.assert_called_with(expected_filename, "w")
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_integration_all_new_config_fields(
+        self, mock_parser_factory, mock_github_client
+    ):
+        """Test integration with all new configuration fields."""
+        # Setup mocks
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "test/repo",
+            "version": "forced-version",
+            "files": {},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Configuration using all new fields
+        config = RepoConfig(
+            repo="test/integration-repo",
+            description="Integration test",
+            versions=["v1.0.0"],
+            parser_type="test",
+            paths={"Category": "path"},
+            fetch_strategy="directory_names",
+            version_override="forced-version",
+            output_filename_slug="integration.test",
+        )
+
+        with (
+            patch(
+                "src.repo_modules_by_version.main.get_repo_config_with_versions",
+                return_value=config,
+            ),
+            patch(
+                "src.repo_modules_by_version.main.get_available_repos",
+                return_value={"test-repo": config},
+            ),
+            patch(
+                "sys.argv",
+                ["main.py", "--repo", "test-repo", "--version", "user-input"],
+            ),
+            patch("builtins.open", create=True) as mock_open,
+            patch("os.path.exists", return_value=False),
+        ):
+            mock_file = Mock()
+            mock_open.return_value.__enter__.return_value = mock_file
+
+            from src.repo_modules_by_version.main import main
+
+            main()
+
+            # Verify all configuration fields were used correctly
+            github_call = mock_github.fetch_repository_data.call_args
+
+            # Check version override was applied
+            assert github_call[0][1] == "forced-version"  # version parameter
+
+            # Check fetch strategy was passed
+            assert github_call[0][5] == "directory_names"  # fetch_strategy parameter
+
+            # Check filename used custom slug
+            expected_filename = "integration.test_modules_version_forced-version.txt"
+            mock_open.assert_called_with(expected_filename, "w")

--- a/tests/test_repo_modules_by_version/test_master_override.py
+++ b/tests/test_repo_modules_by_version/test_master_override.py
@@ -1,0 +1,313 @@
+"""
+Tests for prebid.github.io master version override functionality.
+
+This test suite validates:
+- Master override works for prebid.github.io repository
+- Other repositories are not affected by master override
+- Version parameter is correctly overridden
+- Logging shows correct override behavior
+"""
+
+from unittest.mock import Mock, patch
+
+from src.repo_modules_by_version.config import RepoConfig
+
+
+class TestMasterOverride:
+    """Test master version override functionality for prebid.github.io."""
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_prebid_docs_master_override(self, mock_parser_factory, mock_github_client):
+        """Test that prebid.github.io always uses master version regardless of input."""
+        # Mock the necessary components
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "prebid/prebid.github.io",
+            "version": "master",  # Should always be master
+            "paths": {"dev-docs/bidders": {"dev-docs/bidders/test.md": ""}},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Mock config for prebid-docs
+        with (
+            patch(
+                "src.repo_modules_by_version.main.get_repo_config_with_versions"
+            ) as mock_get_config,
+            patch(
+                "src.repo_modules_by_version.main.get_available_repos"
+            ) as mock_get_repos,
+        ):
+            mock_config = RepoConfig(
+                repo="prebid/prebid.github.io",
+                description="Prebid Documentation site",
+                versions=["master"],
+                parser_type="prebid_docs",
+                paths={"Bid Adapters": "dev-docs/bidders"},
+            )
+            mock_get_config.return_value = mock_config
+            mock_get_repos.return_value = {"prebid-docs": mock_config}
+
+            # Test with different version inputs - should all use master
+            test_versions = ["v1.0.0", "feature-branch", "some-other-version", "master"]
+
+            for input_version in test_versions:
+                mock_github.fetch_repository_data.reset_mock()
+
+                from src.repo_modules_by_version.main import main
+
+                # Mock sys.argv with different versions
+                with patch(
+                    "sys.argv",
+                    ["main.py", "--repo", "prebid-docs", "--version", input_version],
+                ):
+                    with patch("builtins.open", create=True) as mock_open:
+                        mock_open.return_value.__enter__.return_value.write = Mock()
+                        main()
+
+                # Verify that fetch_repository_data was called with master version
+                mock_github.fetch_repository_data.assert_called_once()
+                call_args = mock_github.fetch_repository_data.call_args
+
+                # The version argument should be "master" regardless of input
+                assert (
+                    call_args[0][1] == "master"
+                ), f"Expected master version, got {call_args[0][1]} for input {input_version}"
+
+    @patch("src.repo_modules_by_version.main.GitHubClient")
+    @patch("src.repo_modules_by_version.main.ParserFactory")
+    def test_other_repos_not_affected_by_master_override(
+        self, mock_parser_factory, mock_github_client
+    ):
+        """Test that other repositories are not affected by master override logic."""
+        # Mock the necessary components
+        mock_github = Mock()
+        mock_github_client.return_value = mock_github
+        mock_github.fetch_repository_data.return_value = {
+            "repo": "prebid/Prebid.js",
+            "version": "v9.51.0",  # Should preserve the input version
+            "files": {"modules/testBidAdapter.js": ""},
+        }
+
+        mock_factory = Mock()
+        mock_parser_factory.return_value = mock_factory
+        mock_parser = Mock()
+        mock_parser.parse.return_value = "test output"
+        mock_factory.get_parser.return_value = mock_parser
+
+        # Test with different repositories
+        test_configs = [
+            {
+                "repo_name": "prebid-js",
+                "repo_url": "prebid/Prebid.js",
+                "parser_type": "prebid_js",
+                "modules_path": "modules",
+                "paths": None,
+                "test_version": "v9.51.0",
+            },
+            {
+                "repo_name": "prebid-server",
+                "repo_url": "prebid/prebid-server",
+                "parser_type": "prebid_server_go",
+                "modules_path": None,
+                "paths": {"Bid Adapters": "adapters"},
+                "test_version": "v3.8.0",
+            },
+            {
+                "repo_name": "prebid-server-java",
+                "repo_url": "prebid/prebid-server-java",
+                "parser_type": "prebid_server_java",
+                "modules_path": None,
+                "paths": {"Bid Adapters": "src/main/java/org/prebid/server/bidder"},
+                "test_version": "v3.27.0",
+            },
+        ]
+
+        for config in test_configs:
+            mock_github.fetch_repository_data.reset_mock()
+
+            # Mock config for current repo
+            with (
+                patch(
+                    "src.repo_modules_by_version.main.get_repo_config_with_versions"
+                ) as mock_get_config,
+                patch(
+                    "src.repo_modules_by_version.main.get_available_repos"
+                ) as mock_get_repos,
+            ):
+                mock_repo_config = RepoConfig(
+                    repo=config["repo_url"],
+                    description="Test",
+                    versions=["master"],
+                    parser_type=config["parser_type"],
+                    paths=config["paths"],
+                    modules_path=config["modules_path"],
+                )
+                mock_get_config.return_value = mock_repo_config
+                mock_get_repos.return_value = {config["repo_name"]: mock_repo_config}
+
+                from src.repo_modules_by_version.main import main
+
+                # Mock sys.argv
+                with patch(
+                    "sys.argv",
+                    [
+                        "main.py",
+                        "--repo",
+                        config["repo_name"],
+                        "--version",
+                        config["test_version"],
+                    ],
+                ):
+                    with patch("builtins.open", create=True) as mock_open:
+                        mock_open.return_value.__enter__.return_value.write = Mock()
+                        main()
+
+                # Verify that fetch_repository_data was called with the original version
+                mock_github.fetch_repository_data.assert_called_once()
+                call_args = mock_github.fetch_repository_data.call_args
+
+                # The version should be preserved (not changed to master)
+                assert (
+                    call_args[0][1] == config["test_version"]
+                ), f"Version should be preserved for {config['repo_name']}, expected {config['test_version']}, got {call_args[0][1]}"
+
+    def test_master_override_logic_isolation(self):
+        """Test the master override logic in isolation."""
+
+        # Simulate the logic from main.py
+        def apply_master_override(repo_url, input_version):
+            version = input_version
+            if repo_url == "prebid/prebid.github.io":
+                version = "master"
+            return version
+
+        # Test cases
+        test_cases = [
+            # (repo_url, input_version, expected_output)
+            ("prebid/prebid.github.io", "v1.0.0", "master"),
+            ("prebid/prebid.github.io", "feature-branch", "master"),
+            ("prebid/prebid.github.io", "master", "master"),
+            ("prebid/prebid.github.io", "any-version", "master"),
+            ("prebid/Prebid.js", "v9.51.0", "v9.51.0"),
+            ("prebid/prebid-server", "v3.8.0", "v3.8.0"),
+            ("prebid/prebid-server-java", "v3.27.0", "v3.27.0"),
+            ("other/repo", "v1.0.0", "v1.0.0"),
+        ]
+
+        for repo_url, input_version, expected_output in test_cases:
+            result = apply_master_override(repo_url, input_version)
+            assert (
+                result == expected_output
+            ), f"For repo {repo_url} with version {input_version}, expected {expected_output}, got {result}"
+
+    @patch("src.repo_modules_by_version.main.logger")
+    def test_master_override_preserves_original_main_logic(self, mock_logger):
+        """Test that master override doesn't break other main function logic."""
+        # This test ensures the override is properly integrated
+
+        # Test the version determination logic
+        def simulate_version_logic(repo_url, args_version):
+            version = args_version
+
+            # Original logic would go here (version menu, etc.)
+            # Then the override
+            if repo_url == "prebid/prebid.github.io":
+                version = "master"
+
+            return version
+
+        # Test that override happens after other version logic
+        result = simulate_version_logic("prebid/prebid.github.io", "user-input-version")
+        assert result == "master"
+
+        # Test that non-prebid.github.io repos are unaffected
+        result = simulate_version_logic("prebid/Prebid.js", "v9.51.0")
+        assert result == "v9.51.0"
+
+    def test_master_override_with_interactive_mode(self):
+        """Test that master override works even when version comes from interactive selection."""
+
+        # Simulate interactive mode where user selects a version
+        def simulate_interactive_selection(repo_url, selected_version):
+            version = selected_version  # From user interaction
+
+            # Apply override after user selection
+            if repo_url == "prebid/prebid.github.io":
+                version = "master"
+
+            return version
+
+        # Test that even if user selects different version, it gets overridden
+        result = simulate_interactive_selection("prebid/prebid.github.io", "v2.0.0")
+        assert result == "master"
+
+        # Test that other repos preserve user selection
+        result = simulate_interactive_selection("prebid/Prebid.js", "v9.50.0")
+        assert result == "v9.50.0"
+
+
+class TestMasterOverrideIntegration:
+    """Integration tests for master override functionality."""
+
+    def test_master_override_filename_generation(self):
+        """Test that master override affects filename generation correctly."""
+        # Simulate filename generation with master override
+        repo_url = "prebid/prebid.github.io"
+        input_version = "some-feature-branch"
+
+        # Apply override
+        version = "master" if repo_url == "prebid/prebid.github.io" else input_version
+
+        # Generate filename
+        owner, repo = repo_url.split("/")
+        repo_name = repo.lower().replace("-", ".")
+        version_clean = version.replace("/", "_")
+        filename = f"{repo_name}_modules_version_{version_clean}.txt"
+
+        # Should always generate master filename for prebid.github.io
+        assert filename == "prebid.github.io_modules_version_master.txt"
+
+    def test_master_override_with_all_input_methods(self):
+        """Test master override with different ways of specifying version."""
+        repo_url = "prebid/prebid.github.io"
+
+        # Different ways version might be specified
+        version_sources = [
+            "command_line_arg",
+            "interactive_menu_selection",
+            "config_default",
+            "environment_variable",
+        ]
+
+        # All should result in master for prebid.github.io
+        for source in version_sources:
+            version = "master" if repo_url == "prebid/prebid.github.io" else source
+            assert version == "master"
+
+    def test_master_override_error_handling(self):
+        """Test that master override doesn't interfere with error handling."""
+        # Test with None version
+        repo_url = "prebid/prebid.github.io"
+        input_version = None
+
+        # Even with None input, should get master for prebid.github.io
+        version = input_version
+        if repo_url == "prebid/prebid.github.io":
+            version = "master"
+
+        assert version == "master"
+
+        # Test with empty string
+        input_version = ""
+        version = input_version
+        if repo_url == "prebid/prebid.github.io":
+            version = "master"
+
+        assert version == "master"

--- a/tests/test_repo_modules_by_version/test_master_override.py
+++ b/tests/test_repo_modules_by_version/test_master_override.py
@@ -50,6 +50,9 @@ class TestMasterOverride:
                 versions=["master"],
                 parser_type="prebid_docs",
                 paths={"Bid Adapters": "dev-docs/bidders"},
+                fetch_strategy="filenames_only",
+                version_override="master",  # Configuration-driven override
+                output_filename_slug="prebid.github.io",
             )
             mock_get_config.return_value = mock_config
             mock_get_repos.return_value = {"prebid-docs": mock_config}
@@ -148,6 +151,12 @@ class TestMasterOverride:
                     parser_type=config["parser_type"],
                     paths=config["paths"],
                     modules_path=config["modules_path"],
+                    fetch_strategy=(
+                        "filenames_only"
+                        if config["modules_path"]
+                        else "directory_names"
+                    ),
+                    # No version_override for non-prebid-docs repos
                 )
                 mock_get_config.return_value = mock_repo_config
                 mock_get_repos.return_value = {config["repo_name"]: mock_repo_config}

--- a/tests/test_repo_modules_by_version/test_prebid_docs_parser.py
+++ b/tests/test_repo_modules_by_version/test_prebid_docs_parser.py
@@ -1,0 +1,281 @@
+"""
+Tests for the PrebidDocsParser
+"""
+
+from src.repo_modules_by_version.config import RepoConfig
+from src.repo_modules_by_version.parser_factory import PrebidDocsParser
+
+
+class TestPrebidDocsParser:
+    """Test suite for PrebidDocsParser."""
+
+    def test_prebid_docs_parser_creation(self):
+        """Test that PrebidDocsParser can be created with proper config."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+        assert parser.config == config
+
+    def test_prebid_docs_parser_categorize_bid_adapters(self):
+        """Test categorizing bid adapters from documentation files."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock data for bid adapters
+        files = {
+            "dev-docs/bidders/appnexus.md": "",
+            "dev-docs/bidders/rubicon.md": "",
+            "dev-docs/bidders/pubmatic.md": "",
+        }
+
+        result = parser._categorize_by_path("Bid Adapters", "dev-docs/bidders", files)
+
+        assert "Bid Adapters" in result
+        assert set(result["Bid Adapters"]) == {"appnexus", "rubicon", "pubmatic"}
+
+    def test_prebid_docs_parser_categorize_analytics_adapters(self):
+        """Test categorizing analytics adapters from documentation files."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock data for analytics adapters
+        files = {
+            "dev-docs/analytics/pubstack.md": "",
+            "dev-docs/analytics/agma.md": "",
+            "dev-docs/analytics/generic.md": "",
+        }
+
+        result = parser._categorize_by_path(
+            "Analytics Adapters", "dev-docs/analytics", files
+        )
+
+        assert "Analytics Adapters" in result
+        assert set(result["Analytics Adapters"]) == {"pubstack", "agma", "generic"}
+
+    def test_prebid_docs_parser_categorize_identity_modules(self):
+        """Test categorizing identity modules from documentation files."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock data for identity modules
+        files = {
+            "dev-docs/modules/userid-submodules/id5.md": "",
+            "dev-docs/modules/userid-submodules/liveintent.md": "",
+            "dev-docs/modules/userid-submodules/criteo.md": "",
+        }
+
+        result = parser._categorize_by_path(
+            "Identity Modules", "dev-docs/modules/userid-submodules", files
+        )
+
+        assert "Identity Modules" in result
+        assert set(result["Identity Modules"]) == {"id5", "liveintent", "criteo"}
+
+    def test_prebid_docs_parser_categorize_rtd_modules(self):
+        """Test categorizing Real-Time Data modules with proper suffix removal."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock data for RTD modules
+        files = {
+            "dev-docs/modules/confiantRtdProvider.md": "",
+            "dev-docs/modules/greenbidsRtdProvider.md": "",
+            "dev-docs/modules/51DegreesRtdProvider.md": "",
+        }
+
+        result = parser._categorize_by_path(
+            "Real-Time Data Modules", "dev-docs/modules", files
+        )
+
+        assert "Real-Time Data Modules" in result
+        assert set(result["Real-Time Data Modules"]) == {
+            "confiant",
+            "greenbids",
+            "51Degrees",
+        }
+
+    def test_prebid_docs_parser_categorize_video_modules(self):
+        """Test categorizing Video modules with proper suffix removal."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock data for Video modules
+        files = {
+            "dev-docs/modules/jwplayerVideoProvider.md": "",
+            "dev-docs/modules/videojsVideoProvider.md": "",
+        }
+
+        result = parser._categorize_by_path("Video Modules", "dev-docs/modules", files)
+
+        assert "Video Modules" in result
+        assert set(result["Video Modules"]) == {"jwplayer", "videojs"}
+
+    def test_prebid_docs_parser_categorize_other_modules(self):
+        """Test categorizing Other modules (no special suffix)."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock data for other modules
+        files = {
+            "dev-docs/modules/currency.md": "",
+            "dev-docs/modules/floors.md": "",
+            "dev-docs/modules/debugging.md": "",
+        }
+
+        result = parser._categorize_by_path("Other Modules", "dev-docs/modules", files)
+
+        assert "Other Modules" in result
+        assert set(result["Other Modules"]) == {"currency", "floors", "debugging"}
+
+    def test_prebid_docs_parser_parse_full_data(self):
+        """Test parsing complete data structure."""
+        config = RepoConfig(
+            repo="prebid/prebid.github.io",
+            description="Prebid documentation site",
+            versions=["master"],
+            parser_type="prebid_docs",
+            paths={
+                "Bid Adapters": "dev-docs/bidders",
+                "Analytics Adapters": "dev-docs/analytics",
+                "Identity Modules": "dev-docs/modules/userid-submodules",
+                "Real-Time Data Modules": "dev-docs/modules",
+                "Video Modules": "dev-docs/modules",
+                "Other Modules": "dev-docs/modules",
+            },
+        )
+        parser = PrebidDocsParser(config)
+
+        # Mock complete data structure
+        data = {
+            "repo": "prebid/prebid.github.io",
+            "version": "master",
+            "paths": {
+                "dev-docs/bidders": {
+                    "dev-docs/bidders/appnexus.md": "",
+                    "dev-docs/bidders/rubicon.md": "",
+                },
+                "dev-docs/analytics": {
+                    "dev-docs/analytics/pubstack.md": "",
+                    "dev-docs/analytics/agma.md": "",
+                },
+                "dev-docs/modules/userid-submodules": {
+                    "dev-docs/modules/userid-submodules/id5.md": "",
+                },
+                "dev-docs/modules": {
+                    "dev-docs/modules/confiantRtdProvider.md": "",
+                    "dev-docs/modules/currency.md": "",
+                },
+            },
+        }
+
+        result = parser.parse(data)
+
+        # Verify the output contains all sections
+        assert "Repository: prebid/prebid.github.io" in result
+        assert "Version: master" in result
+        assert "Prebid Documentation Categories:" in result
+        assert "📦 Bid Adapters" in result
+        assert "📦 Analytics Adapters" in result
+        assert "📦 Identity Modules" in result
+        assert "📦 Real-Time Data Modules" in result
+        assert "📦 Other Modules" in result
+        assert "JSON Output:" in result
+
+        # Verify specific content
+        assert "appnexus" in result
+        assert "rubicon" in result
+        assert "pubstack" in result
+        assert "agma" in result
+        assert "id5" in result
+        assert "confiant" in result  # Should have RtdProvider removed
+        assert "currency" in result

--- a/tests/test_repo_modules_by_version/test_prebid_modules_parser.py
+++ b/tests/test_repo_modules_by_version/test_prebid_modules_parser.py
@@ -1,0 +1,184 @@
+"""
+Tests for PrebidJSParser functionality
+"""
+
+import json
+
+from src.repo_modules_by_version.config import RepoConfig
+from src.repo_modules_by_version.parser_factory import PrebidJSParser
+
+
+class TestPrebidJSParser:
+    """Test PrebidJSParser implementation."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = RepoConfig(
+            repo="prebid/Prebid.js",
+            directory="modules",
+            description="Test repository",
+            versions=["master"],
+            parser_type="prebid_js",
+            modules_path="modules",
+        )
+        self.parser = PrebidJSParser(self.config)
+
+    def test_prebid_modules_parser_initialization(self):
+        """Test PrebidJSParser can be initialized."""
+        assert isinstance(self.parser, PrebidJSParser)
+        assert self.parser.config == self.config
+
+    def test_categorize_bid_adapters(self):
+        """Test categorization of bid adapters."""
+        files = {
+            "modules/appnexusBidAdapter.js": "content",
+            "modules/rubiconBidAdapter.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        assert "appnexus" in categories["bid_adapters"]
+        assert "rubicon" in categories["bid_adapters"]
+        assert len(categories["bid_adapters"]) == 2
+
+    def test_categorize_analytics_adapters(self):
+        """Test categorization of analytics adapters."""
+        files = {
+            "modules/googleAnalyticsAnalyticsAdapter.js": "content",
+            "modules/facebookAnalyticsAdapter.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        assert "googleAnalytics" in categories["analytics_adapters"]
+        assert "facebook" in categories["analytics_adapters"]
+        assert len(categories["analytics_adapters"]) == 2
+
+    def test_categorize_rtd_modules(self):
+        """Test categorization of RTD modules."""
+        files = {
+            "modules/facebookRtdProvider.js": "content",
+            "modules/amazonRtdProvider.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        assert "facebook" in categories["rtd_modules"]
+        assert "amazon" in categories["rtd_modules"]
+        assert len(categories["rtd_modules"]) == 2
+
+    def test_categorize_identity_modules(self):
+        """Test categorization of identity modules."""
+        files = {
+            "modules/facebookIdSystem.js": "content",
+            "modules/googleIdSystem.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        assert "facebook" in categories["identity_modules"]
+        assert "google" in categories["identity_modules"]
+        assert len(categories["identity_modules"]) == 2
+
+    def test_categorize_other_modules(self):
+        """Test categorization of other modules."""
+        files = {
+            "modules/currency.js": "content",
+            "modules/consentManagement.js": "content",
+            "modules/userSync.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        assert "currency" in categories["other_modules"]
+        assert "consentManagement" in categories["other_modules"]
+        assert "userSync" in categories["other_modules"]
+        assert len(categories["other_modules"]) == 3
+
+    def test_ignore_non_js_files(self):
+        """Test that non-.js files are ignored."""
+        files = {
+            "modules/README.md": "content",
+            "modules/config.yaml": "content",
+            "modules/appnexusBidAdapter.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        # Only the .js file should be categorized
+        total_modules = sum(len(modules) for modules in categories.values())
+        assert total_modules == 1
+        assert "appnexus" in categories["bid_adapters"]
+
+    def test_ignore_subdirectory_files(self):
+        """Test that files in subdirectories are ignored."""
+        files = {
+            "modules/appnexusBidAdapter.js": "content",
+            "modules/subfolder/nestedFile.js": "content",
+            "modules/utils/helperFile.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        # Only the root level .js file should be categorized
+        total_modules = sum(len(modules) for modules in categories.values())
+        assert total_modules == 1
+        assert "appnexus" in categories["bid_adapters"]
+
+    def test_parse_output_format(self):
+        """Test that parse method produces correctly formatted output."""
+        data = {
+            "repo": "prebid/Prebid.js",
+            "version": "master",
+            "directory": "modules",
+            "files": {
+                "modules/appnexusBidAdapter.js": "content",
+                "modules/googleAnalyticsAnalyticsAdapter.js": "content",
+                "modules/currency.js": "content",
+            },
+            "metadata": {"commit_sha": "abc123", "total_files": 3},
+        }
+
+        result = self.parser.parse(data)
+
+        assert "Repository: prebid/Prebid.js" in result
+        assert "Version: master" in result
+        assert "Modules Directory: modules" in result
+        assert "Bid Adapters (1):" in result
+        assert "Analytics Adapters (1):" in result
+        assert "Other Modules (1):" in result
+        assert "JSON Output:" in result
+
+        # Check that JSON is valid
+        json_start = result.find('{\n  "bid_adapters"')
+        json_end = result.rfind("}") + 1
+        json_output = result[json_start:json_end]
+        parsed_json = json.loads(json_output)
+
+        assert "bid_adapters" in parsed_json
+        assert "analytics_adapters" in parsed_json
+        assert "other_modules" in parsed_json
+
+    def test_mixed_categories(self):
+        """Test with files from all categories."""
+        files = {
+            "modules/appnexusBidAdapter.js": "content",
+            "modules/rubiconBidAdapter.js": "content",
+            "modules/googleAnalyticsAnalyticsAdapter.js": "content",
+            "modules/amazonRtdProvider.js": "content",
+            "modules/facebookIdSystem.js": "content",
+            "modules/currency.js": "content",
+            "modules/consentManagement.js": "content",
+        }
+
+        categories = self.parser._categorize_modules(files)
+
+        assert len(categories["bid_adapters"]) == 2
+        assert len(categories["analytics_adapters"]) == 1
+        assert len(categories["rtd_modules"]) == 1
+        assert len(categories["identity_modules"]) == 1
+        assert len(categories["other_modules"]) == 2
+
+        # Verify total count
+        total_modules = sum(len(modules) for modules in categories.values())
+        assert total_modules == 7

--- a/tests/test_repo_modules_by_version/test_prebid_server_java_parser.py
+++ b/tests/test_repo_modules_by_version/test_prebid_server_java_parser.py
@@ -1,0 +1,214 @@
+"""
+Tests for the PrebidServerJavaParser
+"""
+
+from src.repo_modules_by_version.config import RepoConfig
+from src.repo_modules_by_version.parser_factory import PrebidServerJavaParser
+
+
+class TestPrebidServerJavaParser:
+    """Test suite for PrebidServerJavaParser."""
+
+    def test_prebid_server_java_parser_creation(self):
+        """Test that PrebidServerJavaParser can be created with proper config."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Prebid Server Java implementation",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={
+                "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+                "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+                "General Modules": "extra/modules",
+                "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            },
+        )
+        parser = PrebidServerJavaParser(config)
+        assert parser.config == config
+
+    def test_prebid_server_java_parser_categorize_bid_adapters(self):
+        """Test categorizing bid adapters."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Prebid Server Java implementation",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={
+                "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+                "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+                "General Modules": "extra/modules",
+                "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            },
+        )
+        parser = PrebidServerJavaParser(config)
+
+        # Mock data for bid adapters
+        files = {
+            "src/main/java/org/prebid/server/bidder/appnexus": "",
+            "src/main/java/org/prebid/server/bidder/rubicon": "",
+            "src/main/java/org/prebid/server/bidder/pubmatic": "",
+        }
+
+        result = parser._categorize_by_path(
+            "Bid Adapters", "src/main/java/org/prebid/server/bidder", files
+        )
+
+        assert "Bid Adapters" in result
+        assert set(result["Bid Adapters"]) == {"appnexus", "rubicon", "pubmatic"}
+
+    def test_prebid_server_java_parser_categorize_analytics_adapters(self):
+        """Test categorizing analytics adapters."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Prebid Server Java implementation",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={
+                "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+                "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+                "General Modules": "extra/modules",
+                "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            },
+        )
+        parser = PrebidServerJavaParser(config)
+
+        # Mock data for analytics adapters
+        files = {
+            "src/main/java/org/prebid/server/analytics/reporter/pubstack": "",
+            "src/main/java/org/prebid/server/analytics/reporter/agma": "",
+            "src/main/java/org/prebid/server/analytics/reporter/log": "",  # Should be excluded
+        }
+
+        result = parser._categorize_by_path(
+            "Analytics Adapters",
+            "src/main/java/org/prebid/server/analytics/reporter",
+            files,
+        )
+
+        assert "Analytics Adapters" in result
+        assert set(result["Analytics Adapters"]) == {"pubstack", "agma"}
+
+    def test_prebid_server_java_parser_categorize_general_modules(self):
+        """Test categorizing general modules with proper formatting."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Prebid Server Java implementation",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={
+                "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+                "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+                "General Modules": "extra/modules",
+                "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            },
+        )
+        parser = PrebidServerJavaParser(config)
+
+        # Mock data for general modules
+        files = {
+            "extra/modules/pb-ortb2-blocking": "",
+            "extra/modules/pb-request-correction": "",
+            "extra/modules/normal-module": "",
+        }
+
+        result = parser._categorize_by_path("General Modules", "extra/modules", files)
+
+        assert "General Modules" in result
+        expected_modules = {
+            "ortb2 blocking",  # pb- prefix removed, - replaced with space
+            "request correction",  # pb- prefix removed, - replaced with space
+            "normal module",  # just - replaced with space
+        }
+        assert set(result["General Modules"]) == expected_modules
+
+    def test_prebid_server_java_parser_categorize_privacy_modules(self):
+        """Test categorizing privacy modules."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Prebid Server Java implementation",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={
+                "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+                "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+                "General Modules": "extra/modules",
+                "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            },
+        )
+        parser = PrebidServerJavaParser(config)
+
+        # Mock data for privacy modules
+        files = {
+            "src/main/java/org/prebid/server/activity/infrastructure/privacy/uscustomlogic": "",
+            "src/main/java/org/prebid/server/activity/infrastructure/privacy/usnat": "",
+        }
+
+        result = parser._categorize_by_path(
+            "Privacy Modules",
+            "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            files,
+        )
+
+        assert "Privacy Modules" in result
+        assert set(result["Privacy Modules"]) == {"uscustomlogic", "usnat"}
+
+    def test_prebid_server_java_parser_parse_full_data(self):
+        """Test parsing complete data structure."""
+        config = RepoConfig(
+            repo="prebid/prebid-server-java",
+            description="Prebid Server Java implementation",
+            versions=["master"],
+            parser_type="prebid_server_java",
+            paths={
+                "Bid Adapters": "src/main/java/org/prebid/server/bidder",
+                "Analytics Adapters": "src/main/java/org/prebid/server/analytics/reporter",
+                "General Modules": "extra/modules",
+                "Privacy Modules": "src/main/java/org/prebid/server/activity/infrastructure/privacy",
+            },
+        )
+        parser = PrebidServerJavaParser(config)
+
+        # Mock complete data structure
+        data = {
+            "repo": "prebid/prebid-server-java",
+            "version": "master",
+            "paths": {
+                "src/main/java/org/prebid/server/bidder": {
+                    "src/main/java/org/prebid/server/bidder/appnexus": "",
+                    "src/main/java/org/prebid/server/bidder/rubicon": "",
+                },
+                "src/main/java/org/prebid/server/analytics/reporter": {
+                    "src/main/java/org/prebid/server/analytics/reporter/pubstack": "",
+                    "src/main/java/org/prebid/server/analytics/reporter/log": "",  # Should be excluded
+                },
+                "extra/modules": {
+                    "extra/modules/pb-ortb2-blocking": "",
+                },
+                "src/main/java/org/prebid/server/activity/infrastructure/privacy": {
+                    "src/main/java/org/prebid/server/activity/infrastructure/privacy/uscustomlogic": "",
+                },
+            },
+        }
+
+        result = parser.parse(data)
+
+        # Verify the output contains all sections
+        assert "Repository: prebid/prebid-server-java" in result
+        assert "Version: master" in result
+        assert "Prebid Server Java Categories:" in result
+        assert "📦 Bid Adapters" in result
+        assert "📦 Analytics Adapters" in result
+        assert "📦 General Modules" in result
+        assert "📦 Privacy Modules" in result
+        assert "JSON Output:" in result
+
+        # Verify specific content
+        assert "appnexus" in result
+        assert "rubicon" in result
+        assert "pubstack" in result
+        # Check that log is not in Analytics Adapters specifically (but may appear in other modules like uscustomlogic)
+        assert '"log"' not in result  # Should be excluded from JSON
+        assert (
+            "ortb2 blocking" in result
+        )  # Should have pb- removed and - replaced with space
+        assert "uscustomlogic" in result

--- a/tests/test_repo_modules_by_version/test_prebid_server_parser.py
+++ b/tests/test_repo_modules_by_version/test_prebid_server_parser.py
@@ -1,0 +1,168 @@
+"""
+Tests for the PrebidServerGoParser
+"""
+
+from src.repo_modules_by_version.config import RepoConfig
+from src.repo_modules_by_version.parser_factory import PrebidServerGoParser
+
+
+class TestPrebidServerGoParser:
+    """Test suite for PrebidServerGoParser."""
+
+    def test_prebid_server_go_parser_creation(self):
+        """Test that PrebidServerGoParser can be created with proper config."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Prebid Server Go implementation",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={
+                "Bid Adapters": "adapters",
+                "Analytics Adapters": "analytics",
+                "General Modules": "modules",
+            },
+        )
+        parser = PrebidServerGoParser(config)
+        assert parser.config == config
+
+    def test_prebid_server_parser_categorize_bid_adapters(self):
+        """Test categorizing bid adapters."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Prebid Server Go implementation",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={
+                "Bid Adapters": "adapters",
+                "Analytics Adapters": "analytics",
+                "General Modules": "modules",
+            },
+        )
+        parser = PrebidServerGoParser(config)
+
+        # Mock data for bid adapters
+        files = {
+            "adapters/33across": "",
+            "adapters/appnexus": "",
+            "adapters/rubicon": "",
+        }
+
+        result = parser._categorize_by_path("Bid Adapters", "adapters", files)
+
+        assert "Bid Adapters" in result
+        assert set(result["Bid Adapters"]) == {"33across", "appnexus", "rubicon"}
+
+    def test_prebid_server_parser_categorize_analytics_adapters(self):
+        """Test categorizing analytics adapters."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Prebid Server Go implementation",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={
+                "Bid Adapters": "adapters",
+                "Analytics Adapters": "analytics",
+                "General Modules": "modules",
+            },
+        )
+        parser = PrebidServerGoParser(config)
+
+        # Mock data for analytics adapters
+        files = {
+            "analytics/pubstack": "",
+            "analytics/agma": "",
+            "analytics/build": "",  # Should be excluded
+            "analytics/clients": "",  # Should be excluded
+            "analytics/filesystem": "",  # Should be excluded
+        }
+
+        result = parser._categorize_by_path("Analytics Adapters", "analytics", files)
+
+        assert "Analytics Adapters" in result
+        assert set(result["Analytics Adapters"]) == {"pubstack", "agma"}
+
+    def test_prebid_server_parser_categorize_general_modules(self):
+        """Test categorizing general modules."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Prebid Server Go implementation",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={
+                "Bid Adapters": "adapters",
+                "Analytics Adapters": "analytics",
+                "General Modules": "modules",
+            },
+        )
+        parser = PrebidServerGoParser(config)
+
+        # Mock data for general modules
+        files = {
+            "modules/fiftyonedegrees": "",
+            "modules/fiftyonedegrees/devicedetection": "",
+            "modules/prebid": "",
+            "modules/prebid/ortb2blocking": "",
+            "modules/generator": "",
+        }
+
+        result = parser._categorize_by_path("General Modules", "modules", files)
+
+        assert "General Modules" in result
+        expected_modules = {"fiftyonedegrees devicedetection", "prebid ortb2blocking"}
+        assert set(result["General Modules"]) == expected_modules
+
+    def test_prebid_server_parser_parse_full_data(self):
+        """Test parsing complete data structure."""
+        config = RepoConfig(
+            repo="prebid/prebid-server",
+            description="Prebid Server Go implementation",
+            versions=["master"],
+            parser_type="prebid_server_go",
+            paths={
+                "Bid Adapters": "adapters",
+                "Analytics Adapters": "analytics",
+                "General Modules": "modules",
+            },
+        )
+        parser = PrebidServerGoParser(config)
+
+        # Mock complete data structure
+        data = {
+            "repo": "prebid/prebid-server",
+            "version": "master",
+            "paths": {
+                "adapters": {
+                    "adapters/33across": "",
+                    "adapters/appnexus": "",
+                },
+                "analytics": {
+                    "analytics/pubstack": "",
+                    "analytics/build": "",  # Should be excluded
+                },
+                "modules": {
+                    "modules/fiftyonedegrees": "",
+                    "modules/fiftyonedegrees/devicedetection": "",
+                },
+            },
+        }
+
+        result = parser.parse(data)
+
+        # Verify the output contains all sections
+        assert "Repository: prebid/prebid-server" in result
+        assert "Version: master" in result
+        assert "Prebid Server Go Categories:" in result
+        assert "📦 Bid Adapters" in result
+        assert "📦 Analytics Adapters" in result
+        assert "📦 General Modules" in result
+        assert "JSON Output:" in result
+
+        # Verify specific content
+        assert "33across" in result
+        assert "appnexus" in result
+        assert "pubstack" in result
+        assert "build" not in result  # Should be excluded
+        assert "fiftyonedegrees devicedetection" in result
+        # Should not include directories without subdirectories
+        assert "generator" not in result
+        assert "moduledeps" not in result


### PR DESCRIPTION
Adds dedicated parsers for Prebid.js, Prebid Server (Go and Java), and the Prebid documentation site. These parsers intelligently categorize components like bid adapters, analytics adapters, and other modules, providing structured output in both human-readable and JSON formats.

To support this, the configuration now allows for parsing multiple paths within a repository. The GitHub client is optimized to fetch only directory structures instead of full file contents, significantly improving performance.

Also includes automatic output filename generation and updates to all documentation with new examples.