### PR TITLE
feat: Add specialized parsers for Prebid repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ src/
 
 - `GITHUB_TOKEN` - GitHub Personal Access Token for API access (optional but recommended for higher rate limits)
 
-Last updated: 2025-06-27 18:02:28
+Last updated: 2025-06-27 18:24:18

--- a/prebid.js_modules_version_extract-metadata.txt
+++ b/prebid.js_modules_version_extract-metadata.txt
@@ -1,0 +1,1296 @@
+Repository: prebid/Prebid.js
+Version: extract-metadata
+Modules Directory: modules
+
+Prebid.js Module Categories:
+========================================
+
+📦 Bid Adapters (425):
+------------------------------
+33across
+360playvid
+a1Media
+a4g
+ablida
+acuityads
+ad2iction
+adWMG
+adagio
+adbutler
+addefend
+adf
+adfusion
+adgeneration
+adgrid
+adhash
+adhese
+adipolo
+adkernel
+adkernelAdn
+admaru
+admatic
+admedia
+admixer
+adnow
+adnuntius
+adot
+adpartner
+adplus
+adpone
+adprime
+adquery
+adrelevantis
+adrino
+adriver
+ads_interactive
+adspirit
+adstir
+adtarget
+adtelligent
+adtrgtme
+adtrue
+aduptech
+advangelists
+advertising
+adverxo
+adxcg
+adyoulike
+afp
+aidem
+aja
+akcelo
+alkimi
+ampliffy
+amx
+aniview
+anyclip
+apacdex
+appier
+appnexus
+appush
+apstream
+aseal
+aso
+astraone
+audiencerun
+automatad
+axis
+axonix
+beachfront
+bedigitech
+beop
+between
+beyondmedia
+biddo
+bidglass
+bidmatic
+bidscube
+bidtheatre
+big-richmedia
+bitmedia
+blasto
+bliink
+blockthrough
+blue
+bms
+bmtm
+boldwin
+brainx
+brave
+brid
+bridgewell
+browsi
+bucksense
+buzzoola
+c1x
+cadent_aperture_mx
+caroda
+ccx
+chtnw
+clickforce
+codefuel
+cointraffic
+coinzilla
+colombia
+colossusssp
+compass
+conceptx
+concert
+condorx
+connatix
+connectad
+consumable
+contentexchange
+contxtful
+conversant
+copper6ssp
+cpmstar
+craft
+criteo
+cwire
+dailyhunt
+dailymotion
+datablocks
+datawrkz
+deepintent
+deltaprojects
+dexerto
+dianomi
+digitalMatter
+discovery
+displayio
+distroscale
+djax
+doceree
+docereeAdManager
+dochase
+driftpixel
+dsp_geniee
+dspx
+dvgroup
+dxkulture
+e_volution
+eclick
+edge226
+ehealthcaresolutions
+eightPod
+emtv
+engageya
+eplanning
+epom_dsp
+equativ
+escalax
+eskimi
+etarget
+exads
+exco
+fan
+feedad
+finative
+flipp
+fluct
+freepass
+fwssp
+gamma
+gamoshi
+getintent
+gjirafa
+glomex
+gmossp
+gnet
+goldbach
+greenbids
+grid
+growads
+gumgum
+h12media
+holid
+hybrid
+hypelab
+idx
+illumin
+impactify
+improvedigital
+incrementx
+inmobi
+innity
+insticator
+integr8
+intenze
+interactiveOffers
+invamia
+invibes
+iprom
+iqx
+iqzone
+ivs
+ix
+jixie
+justpremium
+jwplayer
+kargo
+kimberlite
+kiviads
+kobler
+krushmedia
+kubient
+kueezRtb
+lane4
+lasso
+lemmaDigital
+lifestreet
+limelightDigital
+livewrapped
+lkqd
+lm_kiviads
+lockerdome
+logan
+logicad
+loopme
+loyal
+lucead
+lunamediahb
+luponmedia
+mabidder
+madsense
+madvertise
+malltv
+mantis
+marsmedia
+mathildeads
+mediaConsortium
+mediabrama
+mediaeyes
+mediaforce
+mediafuse
+mediago
+mediaimpact
+mediakeys
+medianet
+mediasniper
+mediasquare
+mgid
+mgidX
+microad
+minutemedia
+missena
+mobfoxpb
+mobilefuse
+mobkoi
+my6sense
+mytarget
+nativery
+nativo
+newspassid
+nextMillennium
+nextroll
+nexverse
+nexx360
+nobid
+ogury
+omnidex
+oms
+onetag
+onomagic
+opaMarketplace
+open8
+openweb
+openx
+operaads
+opsco
+optable
+optidigital
+optout
+oraki
+orbidder
+orbitsoft
+otm
+outbrain
+ownadx
+ozone
+padsquad
+pangle
+performax
+pgamssp
+pilotx
+pinkLion
+pixfuture
+playdigo
+preciso
+prisma
+programmaticX
+programmatica
+proxistore
+pstudio
+pubCircle
+pubgenius
+publir
+pubmatic
+pubrise
+pubx
+pulsepoint
+pwbid
+pxyz
+qt
+quantcast
+qwarry
+r2b2
+readpeak
+rediads
+redtram
+relaido
+relay
+relevantdigital
+relevatehealth
+resetdigital
+responsiveAds
+retailspot
+revcontent
+rhythmone
+richaudience
+ringieraxelspringer
+rise
+rixengine
+robusta
+rocketlab
+rtbhouse
+rtbsape
+rubicon
+scattered
+seedingAlliance
+seedtag
+setupad
+sharethrough
+shinez
+shinezRtb
+showheroes-bs
+silvermob
+silverpush
+slimcut
+smaato
+smartadserver
+smarthub
+smartico
+smartx
+smartyads
+smartytech
+smilewanted
+smoot
+snigel
+sonarads
+sonobi
+sovrn
+sparteo
+ssmas
+sspBC
+ssp_geniee
+stackadapt
+startio
+stn
+stroeerCore
+stv
+sublime
+suim
+taboola
+tagoras
+talkads
+tapnative
+tappx
+targetVideo
+teads
+teal
+temedya
+theAdx
+themoneytizer
+tpmn
+trafficgate
+trion
+triplelift
+truereach
+ttd
+twistDigital
+ucfunnel
+underdogmedia
+undertone
+unicorn
+uniquest
+unruly
+valuad
+vdoai
+ventes
+viant
+vibrantmedia
+vidazoo
+videobyte
+videoheroes
+videonow
+videoreach
+vidoomy
+viewdeosDX
+viously
+viqeo
+visiblemeasures
+vistars
+visx
+vlyby
+vox
+vrtcal
+vuukle
+waardex
+welect
+widespace
+winr
+wipes
+xe
+yahooAds
+yandex
+yieldlab
+yieldlift
+yieldlove
+yieldmo
+yieldone
+zeta_global
+zeta_global_ssp
+zmaticoo
+
+📦 Analytics Adapters (60):
+------------------------------
+33across
+AsteriobidPbm
+adWMG
+adagio
+adkernelAdn
+adloox
+adnuntius
+advRed
+adxcg
+adxpremium
+agma
+appier
+asteriobid
+ats
+automatad
+browsi
+byData
+concert
+datablocks
+eightPod
+finteza
+greenbids
+growthCode
+hadron
+id5
+intentIq
+invisibly
+kargo
+liveIntent
+livewrapped
+magnite
+malltv
+medianet
+mobkoi
+nobid
+oolo
+optimon
+oxxion
+pianoDmp
+pubmatic
+pubperf
+pubstack
+pubwise
+pubxai
+pulsepoint
+r2b2
+relevant
+rivr
+roxot
+scaleable
+sharethrough
+smartyads
+symitri
+tercept
+ucfunnel
+uniquest
+yandex
+yieldone
+yuktamedia
+zeta_global_ssp
+
+📦 Rtd Modules (58):
+------------------------------
+1plusX
+51Degrees
+a1Media
+aaxBlockmeter
+adagio
+adlane
+adloox
+adnuntius
+airgrid
+anonymised
+arcspan
+azerionedge
+blueconic
+brandmetrics
+browsi
+cleanio
+confiant
+contxtful
+dgkeyword
+dynamicAdBoost
+experian
+gamera
+geoedge
+goldfishAds
+greenbids
+growthCode
+hadron
+humansecurity
+ias
+im
+intersection
+jwplayer
+liveIntent
+mediafilter
+medianet
+mgid
+mobian
+neuwo
+nodalsAi
+oneKey
+optable
+optimera
+overtone
+oxxion
+permutive
+pubmatic
+pubxai
+qortex
+raveltech
+rayn
+reconciliation
+relevad
+semantiq
+sirdata
+symitriDap
+timeout
+weborama
+wurfl
+
+📦 Identity Modules (58):
+------------------------------
+33across
+admixer
+adquery
+adriver
+adtelligent
+amx
+cee
+connect
+criteo
+czechAd
+dac
+deepintentDpes
+dmd
+euid
+fabrick
+freepass
+ftrack
+gravito
+growthCode
+hadron
+id5
+identityLink
+idx
+imu
+intentIq
+just
+kinesso
+liveIntent
+lmp
+lockrAIM
+lotamePanorama
+merkle
+mobkoi
+mwOpenLink
+mygaru
+navegg
+net
+novatiq
+oneKey
+openPair
+operaads
+pair
+permutiveIdentityManager
+pubProvided
+publink
+pubmatic
+quantcast
+rewardedInterest
+taboola
+tapad
+teads
+tnc
+uid2
+unified
+utiq
+utiqMtp
+yandex
+zeotapIdPlus
+
+📦 Other Modules (29):
+------------------------------
+_moduleMetadata
+adlooxAdServerVideo
+adplayerproVideoProvider
+adpod
+allowActivities
+bidViewability
+bidViewabilityIO
+categoryTranslation
+dfpAdServerVideo
+dfpAdpod
+dsaControl
+express
+freeWheelAdserverVideo
+gamAdServerVideo
+gamAdpod
+gppControl_usnat
+idImportLibrary
+instreamTracking
+jwplayerVideoProvider
+nativeRendering
+paapi
+paapiForGpt
+s2sTesting
+sizeMapping
+sizeMappingV2
+targetVideoAdServerVideo
+topLevelPaapi
+topicsFpdModule
+videojsVideoProvider
+
+JSON Output:
+--------------------
+{
+  "bid_adapters": [
+    "33across",
+    "360playvid",
+    "a1Media",
+    "a4g",
+    "ablida",
+    "acuityads",
+    "ad2iction",
+    "adWMG",
+    "adagio",
+    "adbutler",
+    "addefend",
+    "adf",
+    "adfusion",
+    "adgeneration",
+    "adgrid",
+    "adhash",
+    "adhese",
+    "adipolo",
+    "adkernelAdn",
+    "adkernel",
+    "admaru",
+    "admatic",
+    "admedia",
+    "admixer",
+    "adnow",
+    "adnuntius",
+    "adot",
+    "adpartner",
+    "adplus",
+    "adpone",
+    "adprime",
+    "adquery",
+    "adrelevantis",
+    "adrino",
+    "adriver",
+    "ads_interactive",
+    "adspirit",
+    "adstir",
+    "adtarget",
+    "adtelligent",
+    "adtrgtme",
+    "adtrue",
+    "aduptech",
+    "advangelists",
+    "advertising",
+    "adverxo",
+    "adxcg",
+    "adyoulike",
+    "afp",
+    "aidem",
+    "aja",
+    "akcelo",
+    "alkimi",
+    "ampliffy",
+    "amx",
+    "aniview",
+    "anyclip",
+    "apacdex",
+    "appier",
+    "appnexus",
+    "appush",
+    "apstream",
+    "aseal",
+    "aso",
+    "astraone",
+    "audiencerun",
+    "automatad",
+    "axis",
+    "axonix",
+    "beachfront",
+    "bedigitech",
+    "beop",
+    "between",
+    "beyondmedia",
+    "biddo",
+    "bidglass",
+    "bidmatic",
+    "bidscube",
+    "bidtheatre",
+    "big-richmedia",
+    "bitmedia",
+    "blasto",
+    "bliink",
+    "blockthrough",
+    "blue",
+    "bms",
+    "bmtm",
+    "boldwin",
+    "brainx",
+    "brave",
+    "brid",
+    "bridgewell",
+    "browsi",
+    "bucksense",
+    "buzzoola",
+    "c1x",
+    "cadent_aperture_mx",
+    "caroda",
+    "ccx",
+    "chtnw",
+    "clickforce",
+    "codefuel",
+    "cointraffic",
+    "coinzilla",
+    "colombia",
+    "colossusssp",
+    "compass",
+    "conceptx",
+    "concert",
+    "condorx",
+    "connatix",
+    "connectad",
+    "consumable",
+    "contentexchange",
+    "contxtful",
+    "conversant",
+    "copper6ssp",
+    "cpmstar",
+    "craft",
+    "criteo",
+    "cwire",
+    "dailyhunt",
+    "dailymotion",
+    "datablocks",
+    "datawrkz",
+    "deepintent",
+    "deltaprojects",
+    "dexerto",
+    "dianomi",
+    "digitalMatter",
+    "discovery",
+    "displayio",
+    "distroscale",
+    "djax",
+    "docereeAdManager",
+    "doceree",
+    "dochase",
+    "driftpixel",
+    "dsp_geniee",
+    "dspx",
+    "dvgroup",
+    "dxkulture",
+    "e_volution",
+    "eclick",
+    "edge226",
+    "ehealthcaresolutions",
+    "eightPod",
+    "emtv",
+    "engageya",
+    "eplanning",
+    "epom_dsp",
+    "equativ",
+    "escalax",
+    "eskimi",
+    "etarget",
+    "exads",
+    "exco",
+    "fan",
+    "feedad",
+    "finative",
+    "flipp",
+    "fluct",
+    "freepass",
+    "fwssp",
+    "gamma",
+    "gamoshi",
+    "getintent",
+    "gjirafa",
+    "glomex",
+    "gmossp",
+    "gnet",
+    "goldbach",
+    "greenbids",
+    "grid",
+    "growads",
+    "gumgum",
+    "h12media",
+    "holid",
+    "hybrid",
+    "hypelab",
+    "idx",
+    "illumin",
+    "impactify",
+    "improvedigital",
+    "incrementx",
+    "inmobi",
+    "innity",
+    "insticator",
+    "integr8",
+    "intenze",
+    "interactiveOffers",
+    "invamia",
+    "invibes",
+    "iprom",
+    "iqx",
+    "iqzone",
+    "ivs",
+    "ix",
+    "jixie",
+    "justpremium",
+    "jwplayer",
+    "kargo",
+    "kimberlite",
+    "kiviads",
+    "kobler",
+    "krushmedia",
+    "kubient",
+    "kueezRtb",
+    "lane4",
+    "lasso",
+    "lemmaDigital",
+    "lifestreet",
+    "limelightDigital",
+    "livewrapped",
+    "lkqd",
+    "lm_kiviads",
+    "lockerdome",
+    "logan",
+    "logicad",
+    "loopme",
+    "loyal",
+    "lucead",
+    "lunamediahb",
+    "luponmedia",
+    "mabidder",
+    "madsense",
+    "madvertise",
+    "malltv",
+    "mantis",
+    "marsmedia",
+    "mathildeads",
+    "mediaConsortium",
+    "mediabrama",
+    "mediaeyes",
+    "mediaforce",
+    "mediafuse",
+    "mediago",
+    "mediaimpact",
+    "mediakeys",
+    "medianet",
+    "mediasniper",
+    "mediasquare",
+    "mgid",
+    "mgidX",
+    "microad",
+    "minutemedia",
+    "missena",
+    "mobfoxpb",
+    "mobilefuse",
+    "mobkoi",
+    "my6sense",
+    "mytarget",
+    "nativery",
+    "nativo",
+    "newspassid",
+    "nextMillennium",
+    "nextroll",
+    "nexverse",
+    "nexx360",
+    "nobid",
+    "ogury",
+    "omnidex",
+    "oms",
+    "onetag",
+    "onomagic",
+    "opaMarketplace",
+    "open8",
+    "openweb",
+    "openx",
+    "operaads",
+    "opsco",
+    "optable",
+    "optidigital",
+    "optout",
+    "oraki",
+    "orbidder",
+    "orbitsoft",
+    "otm",
+    "outbrain",
+    "ownadx",
+    "ozone",
+    "padsquad",
+    "pangle",
+    "performax",
+    "pgamssp",
+    "pilotx",
+    "pinkLion",
+    "pixfuture",
+    "playdigo",
+    "preciso",
+    "prisma",
+    "programmaticX",
+    "programmatica",
+    "proxistore",
+    "pstudio",
+    "pubCircle",
+    "pubgenius",
+    "publir",
+    "pubmatic",
+    "pubrise",
+    "pubx",
+    "pulsepoint",
+    "pwbid",
+    "pxyz",
+    "qt",
+    "quantcast",
+    "qwarry",
+    "r2b2",
+    "readpeak",
+    "rediads",
+    "redtram",
+    "relaido",
+    "relay",
+    "relevantdigital",
+    "relevatehealth",
+    "resetdigital",
+    "responsiveAds",
+    "retailspot",
+    "revcontent",
+    "rhythmone",
+    "richaudience",
+    "ringieraxelspringer",
+    "rise",
+    "rixengine",
+    "robusta",
+    "rocketlab",
+    "rtbhouse",
+    "rtbsape",
+    "rubicon",
+    "scattered",
+    "seedingAlliance",
+    "seedtag",
+    "setupad",
+    "sharethrough",
+    "shinez",
+    "shinezRtb",
+    "showheroes-bs",
+    "silvermob",
+    "silverpush",
+    "slimcut",
+    "smaato",
+    "smartadserver",
+    "smarthub",
+    "smartico",
+    "smartx",
+    "smartyads",
+    "smartytech",
+    "smilewanted",
+    "smoot",
+    "snigel",
+    "sonarads",
+    "sonobi",
+    "sovrn",
+    "sparteo",
+    "ssmas",
+    "sspBC",
+    "ssp_geniee",
+    "stackadapt",
+    "startio",
+    "stn",
+    "stroeerCore",
+    "stv",
+    "sublime",
+    "suim",
+    "taboola",
+    "tagoras",
+    "talkads",
+    "tapnative",
+    "tappx",
+    "targetVideo",
+    "teads",
+    "teal",
+    "temedya",
+    "theAdx",
+    "themoneytizer",
+    "tpmn",
+    "trafficgate",
+    "trion",
+    "triplelift",
+    "truereach",
+    "ttd",
+    "twistDigital",
+    "ucfunnel",
+    "underdogmedia",
+    "undertone",
+    "unicorn",
+    "uniquest",
+    "unruly",
+    "valuad",
+    "vdoai",
+    "ventes",
+    "viant",
+    "vibrantmedia",
+    "vidazoo",
+    "videobyte",
+    "videoheroes",
+    "videonow",
+    "videoreach",
+    "vidoomy",
+    "viewdeosDX",
+    "viously",
+    "viqeo",
+    "visiblemeasures",
+    "vistars",
+    "visx",
+    "vlyby",
+    "vox",
+    "vrtcal",
+    "vuukle",
+    "waardex",
+    "welect",
+    "widespace",
+    "winr",
+    "wipes",
+    "xe",
+    "yahooAds",
+    "yandex",
+    "yieldlab",
+    "yieldlift",
+    "yieldlove",
+    "yieldmo",
+    "yieldone",
+    "zeta_global",
+    "zeta_global_ssp",
+    "zmaticoo"
+  ],
+  "analytics_adapters": [
+    "33across",
+    "AsteriobidPbm",
+    "adWMG",
+    "adagio",
+    "adkernelAdn",
+    "adloox",
+    "adnuntius",
+    "advRed",
+    "adxcg",
+    "adxpremium",
+    "agma",
+    "appier",
+    "asteriobid",
+    "ats",
+    "automatad",
+    "browsi",
+    "byData",
+    "concert",
+    "datablocks",
+    "eightPod",
+    "finteza",
+    "greenbids",
+    "growthCode",
+    "hadron",
+    "id5",
+    "intentIq",
+    "invisibly",
+    "kargo",
+    "liveIntent",
+    "livewrapped",
+    "magnite",
+    "malltv",
+    "medianet",
+    "mobkoi",
+    "nobid",
+    "oolo",
+    "optimon",
+    "oxxion",
+    "pianoDmp",
+    "pubmatic",
+    "pubperf",
+    "pubstack",
+    "pubwise",
+    "pubxai",
+    "pulsepoint",
+    "r2b2",
+    "relevant",
+    "rivr",
+    "roxot",
+    "scaleable",
+    "sharethrough",
+    "smartyads",
+    "symitri",
+    "tercept",
+    "ucfunnel",
+    "uniquest",
+    "yandex",
+    "yieldone",
+    "yuktamedia",
+    "zeta_global_ssp"
+  ],
+  "rtd_modules": [
+    "1plusX",
+    "51Degrees",
+    "a1Media",
+    "aaxBlockmeter",
+    "adagio",
+    "adlane",
+    "adloox",
+    "adnuntius",
+    "airgrid",
+    "anonymised",
+    "arcspan",
+    "azerionedge",
+    "blueconic",
+    "brandmetrics",
+    "browsi",
+    "cleanio",
+    "confiant",
+    "contxtful",
+    "dgkeyword",
+    "dynamicAdBoost",
+    "experian",
+    "gamera",
+    "geoedge",
+    "goldfishAds",
+    "greenbids",
+    "growthCode",
+    "hadron",
+    "humansecurity",
+    "ias",
+    "im",
+    "intersection",
+    "jwplayer",
+    "liveIntent",
+    "mediafilter",
+    "medianet",
+    "mgid",
+    "mobian",
+    "neuwo",
+    "nodalsAi",
+    "oneKey",
+    "optable",
+    "optimera",
+    "overtone",
+    "oxxion",
+    "permutive",
+    "pubmatic",
+    "pubxai",
+    "qortex",
+    "raveltech",
+    "rayn",
+    "reconciliation",
+    "relevad",
+    "semantiq",
+    "sirdata",
+    "symitriDap",
+    "timeout",
+    "weborama",
+    "wurfl"
+  ],
+  "identity_modules": [
+    "33across",
+    "admixer",
+    "adquery",
+    "adriver",
+    "adtelligent",
+    "amx",
+    "cee",
+    "connect",
+    "criteo",
+    "czechAd",
+    "dac",
+    "deepintentDpes",
+    "dmd",
+    "euid",
+    "fabrick",
+    "freepass",
+    "ftrack",
+    "gravito",
+    "growthCode",
+    "hadron",
+    "id5",
+    "identityLink",
+    "idx",
+    "imu",
+    "intentIq",
+    "just",
+    "kinesso",
+    "liveIntent",
+    "lmp",
+    "lockrAIM",
+    "lotamePanorama",
+    "merkle",
+    "mobkoi",
+    "mwOpenLink",
+    "mygaru",
+    "navegg",
+    "net",
+    "novatiq",
+    "oneKey",
+    "openPair",
+    "operaads",
+    "pair",
+    "permutiveIdentityManager",
+    "pubProvided",
+    "publink",
+    "pubmatic",
+    "quantcast",
+    "rewardedInterest",
+    "taboola",
+    "tapad",
+    "teads",
+    "tnc",
+    "uid2",
+    "unified",
+    "utiq",
+    "utiqMtp",
+    "yandex",
+    "zeotapIdPlus"
+  ],
+  "other_modules": [
+    "_moduleMetadata",
+    "adlooxAdServerVideo",
+    "adplayerproVideoProvider",
+    "adpod",
+    "allowActivities",
+    "bidViewability",
+    "bidViewabilityIO",
+    "categoryTranslation",
+    "dfpAdServerVideo",
+    "dfpAdpod",
+    "dsaControl",
+    "express",
+    "freeWheelAdserverVideo",
+    "gamAdServerVideo",
+    "gamAdpod",
+    "gppControl_usnat",
+    "idImportLibrary",
+    "instreamTracking",
+    "jwplayerVideoProvider",
+    "nativeRendering",
+    "paapi",
+    "paapiForGpt",
+    "s2sTesting",
+    "sizeMapping",
+    "sizeMappingV2",
+    "targetVideoAdServerVideo",
+    "topLevelPaapi",
+    "topicsFpdModule",
+    "videojsVideoProvider"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "ruff>=0.3.0",
     "black>=24.0.0",
     "pyyaml>=6.0.0",
+    "requests>=2.31.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-instrumentation-requests>=0.41b0",
@@ -74,4 +75,5 @@ extend-exclude = '''
 [dependency-groups]
 dev = [
     "types-pyyaml>=6.0.12.20250516",
+    "types-requests>=2.31.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -160,12 +160,14 @@ dependencies = [
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "ruff" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "types-pyyaml" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -182,11 +184,15 @@ requires-dist = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=0.21.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.3.0" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250516" }]
+dev = [
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
+    { name = "types-requests", specifier = ">=2.31.0" },
+]
 
 [[package]]
 name = "idna"
@@ -549,6 +555,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250611"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/7f/73b3a04a53b0fd2a911d4ec517940ecd6600630b559e4505cc7b68beb5a0/types_requests-2.32.4.20250611.tar.gz", hash = "sha256:741c8777ed6425830bf51e54d6abe245f79b4dcb9019f1622b773463946bf826", size = 23118, upload-time = "2025-06-11T03:11:41.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ea/0be9258c5a4fa1ba2300111aa5a0767ee6d18eb3fd20e91616c12082284d/types_requests-2.32.4.20250611-py3-none-any.whl", hash = "sha256:ad2fe5d3b0cb3c2c902c8815a70e7fb2302c4b8c1f77bdcd738192cdb3878072", size = 20643, upload-time = "2025-06-11T03:11:40.186Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
feat: Add specialized parsers for Prebid repositories

Adds dedicated parsers for Prebid.js, Prebid Server (Go and Java), and the Prebid documentation site. These parsers intelligently categorize components like bid adapters, analytics adapters, and other modules, providing structured output in both human-readable and JSON formats.

To support this, the configuration now allows for parsing multiple paths within a repository. The GitHub client is optimized to fetch only directory structures instead of full file contents, significantly improving performance.

Also includes automatic output filename generation and updates to all documentation with new examples.

feat: Add specialized parsers for Prebid repositories

Adds dedicated parsers for Prebid.js, Prebid Server, and the documentation site to intelligently categorize components like bid and analytics adapters. This provides structured output in both human-readable and JSON formats.

A new `alias-mappings` script is added to support this functionality. The GitHub client is now optimized to fetch only directory structures instead of full file contents, significantly improving performance.

Removes a static, pre-generated module list which is now created dynamically.

feat: Add metadata-based parsing for Prebid.js v10+

Updates the Prebid.js parser to use the `metadata/modules.json` file for versions 10.0 and newer. This provides a more accurate and reliable method for categorizing modules compared to the previous filename-based approach.

The parser now detects the Prebid.js version and dynamically chooses the appropriate parsing strategy. For older versions or if the metadata file is unavailable, it gracefully falls back to the original file-based parsing method.

Adds `requests` as a dependency to fetch the metadata file and includes comprehensive unit tests for the new logic and fallback mechanisms.